### PR TITLE
Backspace can be assigned as a key command. 

### DIFF
--- a/source/dialogs/keyboardsettingsdialog.cpp
+++ b/source/dialogs/keyboardsettingsdialog.cpp
@@ -135,11 +135,13 @@ void KeyboardSettingsDialog::processKeyPress(QKeyEvent *e)
     
     if (key == Qt::Key_Backspace && !text.isEmpty())
     {
-        // Remove shortcut if there is a shortcut already present  (and backspace is pressed)
+        // Remove if there is a shortcut already present (and backspace is pressed)
         setShortcut("");
     }
     else
     {
+        // Add in any modifers like Shift or Ctrl, but remove the keypad modifer
+        // since QKeySequence doesn't handle that well.
         key |= (e->modifiers() & ~Qt::KeypadModifier);
 
         QKeySequence newKeySequence(key);

--- a/source/dialogs/keyboardsettingsdialog.cpp
+++ b/source/dialogs/keyboardsettingsdialog.cpp
@@ -43,6 +43,7 @@ KeyboardSettingsDialog::KeyboardSettingsDialog(
 
     connect(ui->defaultButton, SIGNAL(clicked()), this,
             SLOT(resetToDefaultShortcut()));
+    ui->shortcutEdit->setFocus();
 }
 
 KeyboardSettingsDialog::~KeyboardSettingsDialog()
@@ -134,6 +135,7 @@ void KeyboardSettingsDialog::processKeyPress(QKeyEvent *e)
     
     if (key == Qt::Key_Backspace && !text.isEmpty())
     {
+        // Remove shortcut if there is a shortcut already present  (and backspace is pressed)
         setShortcut("");
     }
     else
@@ -202,6 +204,7 @@ void KeyboardSettingsDialog::activeCommandChanged(QTreeWidgetItem* current,
                                                   QTreeWidgetItem* /*previous*/)
 {
     ui->shortcutEdit->setText(current->text(CommandShortcut));
+    ui->shortcutEdit->setFocus();
 }
 
 void KeyboardSettingsDialog::saveShortcuts()

--- a/source/dialogs/keyboardsettingsdialog.cpp
+++ b/source/dialogs/keyboardsettingsdialog.cpp
@@ -129,15 +129,15 @@ void KeyboardSettingsDialog::processKeyPress(QKeyEvent *e)
         return;
     }
 
-    // Allow the use of backspace to clear the shortcut.
-    if (key == Qt::Key_Backspace)
+    QTreeWidgetItem *item = ui->commandsList->currentItem();
+    QString text = item->text(CommandShortcut);
+    
+    if (key == Qt::Key_Backspace && !text.isEmpty())
     {
         setShortcut("");
     }
     else
     {
-        // Add in any modifers like Shift or Ctrl, but remove the keypad modifer
-        // since QKeySequence doesn't handle that well.
         key |= (e->modifiers() & ~Qt::KeypadModifier);
 
         QKeySequence newKeySequence(key);


### PR DESCRIPTION
This addresses issue #166.
If a keyboard shortcut is already present for said command/action (in the keyboard shortcut options) then backspace will clear that shortcut, if not (i.e there is no command for the action) then it will assign backspace as the command (plus modifiers).
Also, now focus will be drawn to the text box when the dialog is opened and when a shortcut is edited.