### PR TITLE
Add Delete Note and Delete Position Commands to Edit Menu

### DIFF
--- a/source/app/clipboard.cpp
+++ b/source/app/clipboard.cpp
@@ -83,10 +83,11 @@ void Clipboard::copySelection(const ScoreLocation &location)
 {
     const auto selectedPositions = location.getSelectedPositions();
     const int numStrings = location.getStaff().getStringCount();
-
+    
     if (selectedPositions.empty())
         return;
 
+    
     ClipboardSelection selection(numStrings, selectedPositions,
                                  location.getSelectedIrregularGroupings());
 

--- a/source/app/powertabeditor.cpp
+++ b/source/app/powertabeditor.cpp
@@ -2650,6 +2650,9 @@ void PowerTabEditor::createMenus()
     myEditMenu->addAction(myCopyCommand);
     myEditMenu->addAction(myPasteCommand);
     myEditMenu->addSeparator();
+    myEditMenu->addAction(myRemoveNoteCommand);
+    myEditMenu->addAction(myRemovePositionCommand);
+    myEditMenu->addSeparator();
     myEditMenu->addAction(myPolishCommand);
     myEditMenu->addAction(myPolishSystemCommand);
     myEditMenu->addSeparator();


### PR DESCRIPTION
This Fixes #101.
The Issue just mentions adding the delete position command, but I added the delete note command as well for consistency. 
The commands also still remain in the Position Menu.