### PR TITLE
Fix a bunch of warnings on comparisons between signed and unsigned integers

### DIFF
--- a/source/actions/editkeysignature.cpp
+++ b/source/actions/editkeysignature.cpp
@@ -47,7 +47,7 @@ void EditKeySignature::updateFollowingKeySignatures(const KeySignature &oldKey,
     Score &score = myLocation.getScore();
     const int startSystem = myLocation.getSystemIndex();
 
-    for (int i = startSystem; i < score.getSystems().size(); ++i)
+    for (unsigned int i = startSystem; i < score.getSystems().size(); ++i)
     {
         for (Barline &bar : score.getSystems()[i].getBarlines())
         {

--- a/source/actions/editplayer.cpp
+++ b/source/actions/editplayer.cpp
@@ -41,7 +41,7 @@ void EditPlayer::redo()
             {
                 myOriginalChanges.push_back(change);
 
-                for (int i = 0; i < system.getStaves().size(); ++i)
+                for (unsigned int i = 0; i < system.getStaves().size(); ++i)
                 {
                     for (const ActivePlayer &activePlayer :
                          change.getActivePlayers(i))

--- a/source/actions/edittimesignature.cpp
+++ b/source/actions/edittimesignature.cpp
@@ -47,7 +47,7 @@ void EditTimeSignature::updateFollowingTimeSignatures(
     Score &score = myLocation.getScore();
     const int startSystem = myLocation.getSystemIndex();
 
-    for (int i = startSystem; i < score.getSystems().size(); ++i)
+    for (unsigned int i = startSystem; i < score.getSystems().size(); ++i)
     {
         for (Barline &bar : score.getSystems()[i].getBarlines())
         {

--- a/source/actions/removeinstrument.cpp
+++ b/source/actions/removeinstrument.cpp
@@ -39,7 +39,7 @@ void RemoveInstrument::redo()
         {
             myOriginalChanges.push_back(change);
          
-            for (int i = 0; i < system.getStaves().size(); ++i)
+            for (unsigned int i = 0; i < system.getStaves().size(); ++i)
             {
                 for (const ActivePlayer &activePlayer :
                      change.getActivePlayers(i))

--- a/source/actions/removeplayer.cpp
+++ b/source/actions/removeplayer.cpp
@@ -39,7 +39,7 @@ void RemovePlayer::redo()
         {
             myOriginalChanges.push_back(change);
          
-            for (int i = 0; i < system.getStaves().size(); ++i)
+            for (unsigned int i = 0; i < system.getStaves().size(); ++i)
             {
                 for (const ActivePlayer &activePlayer :
                      change.getActivePlayers(i))

--- a/source/app/documentmanager.cpp
+++ b/source/app/documentmanager.cpp
@@ -122,7 +122,7 @@ size_t DocumentManager::getDocumentListSize() const
 
 int DocumentManager::findDocument(const std::string& filepath)
 {
-    for (int i = 0; i < getDocumentListSize(); ++i)
+    for (unsigned int i = 0; i < getDocumentListSize(); ++i)
     {
         Document& doc = getDocument(i);
         

--- a/source/app/scorearea.cpp
+++ b/source/app/scorearea.cpp
@@ -62,7 +62,7 @@ void ScoreArea::renderDocument(const Document &document)
     });
 
     myRenderedSystems.reserve(score.getSystems().size());
-    for (int i = 0; i < score.getSystems().size(); ++i)
+    for (unsigned int i = 0; i < score.getSystems().size(); ++i)
         myRenderedSystems.append(nullptr);
 
 #if 0

--- a/source/dialogs/directiondialog.cpp
+++ b/source/dialogs/directiondialog.cpp
@@ -109,7 +109,7 @@ void DirectionDialog::onRemoveDirection()
     myDirection.removeSymbol(index);
 
     // Rebuild the list of symbols.
-    for (long i = 0; i < myDirection.getSymbols().size(); ++i)
+    for (unsigned long i = 0; i < myDirection.getSymbols().size(); ++i)
         ui->directionComboBox->addItem(QString::number(i + 1));
 
     ui->directionComboBox->setCurrentIndex(

--- a/source/dialogs/gotobarlinedialog.cpp
+++ b/source/dialogs/gotobarlinedialog.cpp
@@ -26,12 +26,12 @@ GoToBarlineDialog::GoToBarlineDialog(QWidget *parent, const Score &score)
 {
     ui->setupUi(this);
 
-    for (long systemIndex = 0; systemIndex < score.getSystems().size();
+    for (unsigned long systemIndex = 0; systemIndex < score.getSystems().size();
          ++systemIndex)
     {
         const System &system = score.getSystems()[systemIndex];
         // Index all barlines except for the end bar.
-        for (long i = 0; i < system.getBarlines().size() - 1; ++i)
+        for (unsigned long i = 0; i < system.getBarlines().size() - 1; ++i)
         {
             myLocations.push_back(ScoreLocation(
                 score, systemIndex, 0, system.getBarlines()[i].getPosition()));

--- a/source/dialogs/playerchangedialog.cpp
+++ b/source/dialogs/playerchangedialog.cpp
@@ -56,7 +56,7 @@ PlayerChangeDialog::PlayerChangeDialog(QWidget *parent, const Score &score,
     // Initialize the dialog with the current staff/instrument for each player.
     if (currentPlayers)
     {
-        for (int staff = 0; staff < system.getStaves().size(); ++staff)
+        for (unsigned int staff = 0; staff < system.getStaves().size(); ++staff)
         {
             std::vector<ActivePlayer> players =
                     currentPlayers->getActivePlayers(staff);

--- a/source/formats/gpx/documentreader.cpp
+++ b/source/formats/gpx/documentreader.cpp
@@ -280,7 +280,7 @@ void Gpx::DocumentReader::readMasterBars(Score &score)
 
     // Set up an initial player change.
     PlayerChange change;
-    for (int i = 0; i < score.getPlayers().size(); ++i)
+    for (unsigned int i = 0; i < score.getPlayers().size(); ++i)
         change.insertActivePlayer(i, ActivePlayer(i, i));
     system.insertPlayerChange(change);
 
@@ -337,8 +337,8 @@ void Gpx::DocumentReader::readMasterBars(Score &score)
 
         int nextPos = startPos;
 
-        for (int i = 0; i < score.getPlayers().size() &&
-             i < static_cast<int>(barIds.size()); ++i)
+        for (unsigned int i = 0; i < score.getPlayers().size() &&
+             i < static_cast<unsigned int>(barIds.size()); ++i)
         {
             Staff &staff = system.getStaves()[i];
             int currentPos = (startPos != 0) ? startPos + 1 : 0;

--- a/source/formats/guitar_pro/guitarproimporter.cpp
+++ b/source/formats/guitar_pro/guitarproimporter.cpp
@@ -313,7 +313,7 @@ void GuitarProImporter::convertScore(const Gp::Document &doc, Score &score)
     {
         // Set up an initial player change.
         PlayerChange change;
-        for (int i = 0; i < score.getPlayers().size(); ++i)
+        for (unsigned int i = 0; i < score.getPlayers().size(); ++i)
             change.insertActivePlayer(i, ActivePlayer(i, i));
         system.insertPlayerChange(change);
     }
@@ -339,7 +339,7 @@ void GuitarProImporter::convertScore(const Gp::Document &doc, Score &score)
 
         // For each player, import the notes from the current measure.
         int nextPos = startPos;
-        for (int i = 0; i < score.getPlayers().size(); ++i)
+        for (unsigned int i = 0; i < score.getPlayers().size(); ++i)
         {
             Staff &staff = system.getStaves()[i];
             const Gp::Staff &gp_staff = measure.myStaves[i];

--- a/source/midi/midifile.cpp
+++ b/source/midi/midifile.cpp
@@ -123,7 +123,7 @@ void MidiFile::load(const Score &score, const LoadOptions &options)
 
     // Set the initial channel volume and pitch bend range..
     std::vector<MidiEventList> regular_tracks(score.getPlayers().size());
-    for (int i = 0; i < score.getPlayers().size(); ++i)
+    for (unsigned int i = 0; i < score.getPlayers().size(); ++i)
     {
         regular_tracks[i].append(
             MidiEvent::volumeChange(0, getChannel(i), Dynamic::fff));
@@ -160,12 +160,12 @@ void MidiFile::load(const Score &score, const LoadOptions &options)
             addTempoEvent(master_track, start_tick, current_tempo, system,
                           current_bar->getPosition(), next_bar->getPosition());
 
-        for (int staff_index = 0; staff_index < system.getStaves().size();
+        for (unsigned int staff_index = 0; staff_index < system.getStaves().size();
              ++staff_index)
         {
             const Staff &staff = system.getStaves()[staff_index];
 
-            for (int voice_index = 0; voice_index < staff.getVoices().size();
+            for (unsigned int voice_index = 0; voice_index < staff.getVoices().size();
                  ++voice_index)
             {
                 const int end_tick = addEventsForBar(

--- a/source/painters/layoutinfo.cpp
+++ b/source/painters/layoutinfo.cpp
@@ -697,7 +697,7 @@ void LayoutInfo::calculateBendLayout(VerticalLayout &layout)
         bool inGroup = false;
         int groupHeight = 0;
 
-        for (int i = 0; i < voice.getPositions().size(); ++i)
+        for (unsigned int i = 0; i < voice.getPositions().size(); ++i)
         {
             const Position &pos = voice.getPositions()[i];
 

--- a/source/score/utils/scoremerger.cpp
+++ b/source/score/utils/scoremerger.cpp
@@ -290,7 +290,7 @@ static int importNotes(
     int length = 0;
 
     // Merge the notes for each staff.
-    for (int i = 0; i < src_system.getStaves().size(); ++i)
+    for (unsigned int i = 0; i < src_system.getStaves().size(); ++i)
     {
         // Ensure that there are enough staves in the destination system.
         if ((!is_bass && num_guitar_staves <= i) ||
@@ -501,7 +501,7 @@ static void mergePlayerChanges(ScoreLocation &dest_loc,
         // staff/player/instrument numbers.
         if (bass_change)
         {
-            for (int i = 0; i < bass_loc.getSystem().getStaves().size(); ++i)
+            for (unsigned int i = 0; i < bass_loc.getSystem().getStaves().size(); ++i)
             {
                 for (const ActivePlayer &player :
                      bass_change->getActivePlayers(i))

--- a/source/widgets/instruments/instrumentpanel.cpp
+++ b/source/widgets/instruments/instrumentpanel.cpp
@@ -36,7 +36,7 @@ void InstrumentPanel::reset(const Score &score)
 {
     clear();
 
-    for (int i = 0; i < score.getInstruments().size(); ++i)
+    for (unsigned int i = 0; i < score.getInstruments().size(); ++i)
     {
         myLayout->addWidget(new InstrumentPanelItem(
             this, i, score.getInstruments()[i], myEditPubSub, myRemovePubSub));

--- a/source/widgets/mixer/mixer.cpp
+++ b/source/widgets/mixer/mixer.cpp
@@ -39,7 +39,7 @@ void Mixer::reset(const Score &score)
 {
     clear();
 
-    for (int i = 0; i < score.getPlayers().size(); ++i)
+    for (unsigned int i = 0; i < score.getPlayers().size(); ++i)
     {
         myLayout->addWidget(new MixerItem(this, i, score.getPlayers()[i],
                                           myDictionary, myEditPubSub,


### PR DESCRIPTION
I'd update the getSystemIndex() and similar methods to return unsigned ints, but I saw some code comparing <= 0 and returning nullptr. So I'm guessing you allow for negative indexes.