### PR TITLE
Cannot change zoom excessively.

### DIFF
--- a/source/widgets/playback/playbackwidget.cpp
+++ b/source/widgets/playback/playbackwidget.cpp
@@ -142,22 +142,8 @@ PlaybackWidget::~PlaybackWidget()
 
 double PlaybackWidget::validateZoom(double percent) 
 {
-    std::vector<double> options = std::vector<double>();
-
-    QLocale locale;
-    for(int i = 0; i < ui->zoomComboBox->count(); ++i) {
-        QString stringRep = ui->zoomComboBox->itemData(i).to()
-            ;
-        qDebug() << stringRep;
-        stringRep = extractPercent(stringRep, locale);
-        double percentage = locale.toDouble(stringRep);
-        
-        options.push_back(percentage);
-    }
-
-    double min = *std::min_element(options.begin(), options.end());
-    double max = *std::max_element(options.begin(), options.end());
-    if(percent < min || percent > max) 
+    
+    if(percent < MIN_ZOOM || percent > MAX_ZOOM) 
     {
         ui->zoomComboBox->setStyleSheet("QComboBox { color : red; }");
     } else 

--- a/source/widgets/playback/playbackwidget.cpp
+++ b/source/widgets/playback/playbackwidget.cpp
@@ -153,6 +153,7 @@ double PlaybackWidget::validateZoom(double percent)
     return boost::algorithm::clamp(percent, MIN_ZOOM, MAX_ZOOM);
 }
 
+
 void PlaybackWidget::reset(const Document &doc)
 {
     ui->filterComboBox->blockSignals(true);

--- a/source/widgets/playback/playbackwidget.cpp
+++ b/source/widgets/playback/playbackwidget.cpp
@@ -22,6 +22,7 @@
 #include <score/staff.h>
 #include <score/score.h>
 #include <widgets/common.h>
+#include<boost/algorithm/clamp.hpp>
 
 static QString getShortcutHint(const QAction &action)
 {
@@ -111,7 +112,7 @@ PlaybackWidget::PlaybackWidget(const QAction &play_pause_command,
     });
 
     ui->zoomComboBox->setValidator(new PercentageValidator(this));
-
+    
     connect(myVoices, SIGNAL(buttonClicked(int)), this,
             SIGNAL(activeVoiceChanged(int)));
     connect(ui->speedSpinner, SIGNAL(valueChanged(int)), this,
@@ -126,13 +127,26 @@ PlaybackWidget::PlaybackWidget(const QAction &play_pause_command,
     connect(ui->zoomComboBox, &QComboBox::currentTextChanged,
             [=](const QString &text) {
         QLocale locale;
-        zoomChanged(locale.toDouble(extractPercent(text, locale)));
+        double percentage = locale.toDouble(extractPercent(text, locale));
+        percentage = validateZoom(percentage);
+        zoomChanged(percentage);
     });
 }
 
 PlaybackWidget::~PlaybackWidget()
 {
     delete ui;
+}
+
+double PlaybackWidget::validateZoom(double percent) 
+{
+    if(percent < MIN_ZOOM || percent > MAX_ZOOM) {
+        ui->zoomComboBox->setStyleSheet("QComboBox { color : red; }");
+    } else {
+        ui->zoomComboBox->setStyleSheet("QComboBox { color : black; }");
+    }
+
+    return boost::algorithm::clamp(percent, MIN_ZOOM, MAX_ZOOM);
 }
 
 void PlaybackWidget::reset(const Document &doc)

--- a/source/widgets/playback/playbackwidget.cpp
+++ b/source/widgets/playback/playbackwidget.cpp
@@ -22,9 +22,8 @@
 #include <score/staff.h>
 #include <score/score.h>
 #include <widgets/common.h>
-#include<boost/algorithm/clamp.hpp>
 
-#include<qdebug.h>
+#include <boost/algorithm/clamp.hpp>
 
 static QString getShortcutHint(const QAction &action)
 {
@@ -142,11 +141,11 @@ PlaybackWidget::~PlaybackWidget()
 
 double PlaybackWidget::validateZoom(double percent) 
 {
-    
     if(percent < MIN_ZOOM || percent > MAX_ZOOM) 
     {
         ui->zoomComboBox->setStyleSheet("QComboBox { color : red; }");
-    } else 
+    } 
+    else 
     {
         ui->zoomComboBox->setStyleSheet("QComboBox { color : black; }");
     }

--- a/source/widgets/playback/playbackwidget.cpp
+++ b/source/widgets/playback/playbackwidget.cpp
@@ -24,6 +24,8 @@
 #include <widgets/common.h>
 #include<boost/algorithm/clamp.hpp>
 
+#include<qdebug.h>
+
 static QString getShortcutHint(const QAction &action)
 {
     if (!action.shortcut().isEmpty())
@@ -140,9 +142,26 @@ PlaybackWidget::~PlaybackWidget()
 
 double PlaybackWidget::validateZoom(double percent) 
 {
-    if(percent < MIN_ZOOM || percent > MAX_ZOOM) {
+    std::vector<double> options = std::vector<double>();
+
+    QLocale locale;
+    for(int i = 0; i < ui->zoomComboBox->count(); ++i) {
+        QString stringRep = ui->zoomComboBox->itemData(i).to()
+            ;
+        qDebug() << stringRep;
+        stringRep = extractPercent(stringRep, locale);
+        double percentage = locale.toDouble(stringRep);
+        
+        options.push_back(percentage);
+    }
+
+    double min = *std::min_element(options.begin(), options.end());
+    double max = *std::max_element(options.begin(), options.end());
+    if(percent < min || percent > max) 
+    {
         ui->zoomComboBox->setStyleSheet("QComboBox { color : red; }");
-    } else {
+    } else 
+    {
         ui->zoomComboBox->setStyleSheet("QComboBox { color : black; }");
     }
 

--- a/source/widgets/playback/playbackwidget.h
+++ b/source/widgets/playback/playbackwidget.h
@@ -59,6 +59,7 @@ signals:
 private:
     void onSettingChanged(const std::string &setting);
     double validateZoom(double percent);
+
     Ui::PlaybackWidget *ui;
     QButtonGroup *myVoices;
 

--- a/source/widgets/playback/playbackwidget.h
+++ b/source/widgets/playback/playbackwidget.h
@@ -58,9 +58,11 @@ signals:
 
 private:
     void onSettingChanged(const std::string &setting);
-
+    double validateZoom(double percent);
     Ui::PlaybackWidget *ui;
     QButtonGroup *myVoices;
+
+    const float MAX_ZOOM = 200, MIN_ZOOM = 25;
 };
 
 #endif


### PR DESCRIPTION
Now the zoom cannot be changed excessively - whereas before you could go to 0% or even 2000
00%(+!).
The `ComboBox` is still editable mind though.
It will also highlight an invalid percentage in red text.

Notes:
-  `MAX_ZOOM` and `MIN_ZOOM` probably shouldn't be hard-coded, but I don't think that there is a way to get the largest and smallest elements in a `ComboBox`. 
 
Edit:
Noticed a few things, so changes to make tomorrow:

- [x] change `if` braces to be consistent 