### PR TITLE
Bug#202

### DIFF
--- a/source/app/powertabeditor.cpp
+++ b/source/app/powertabeditor.cpp
@@ -748,7 +748,7 @@ void PowerTabEditor::shiftBackward()
 
 void PowerTabEditor::removeCurrentPosition()
 {
-	auto location = getLocation();
+    auto location = getLocation();
     bool isNote = location.getNote();
 
     if(!isNote)

--- a/source/app/powertabeditor.cpp
+++ b/source/app/powertabeditor.cpp
@@ -748,8 +748,18 @@ void PowerTabEditor::shiftBackward()
 
 void PowerTabEditor::removeNote()
 {
-    myUndoManager->push(new RemoveNote(getLocation()),
-                        getLocation().getSystemIndex());
+	auto location = getLocation();
+    bool isNote = location.getNote();
+
+    if(!isNote)
+    {
+    	removeSelectedPositions();
+    }
+    else
+    {
+    	myUndoManager->push(new RemoveNote(location),
+    			location.getSystemIndex());
+    }
 }
 
 void PowerTabEditor::removeSelectedPositions()
@@ -3066,7 +3076,7 @@ void PowerTabEditor::updateCommands()
                                              Score::MIN_LINE_SPACING);
     myShiftBackwardCommand->setEnabled(!pos && (position == 0 || !barline) &&
                                        !tempoMarker && !altEnding && !dynamic);
-    myRemoveNoteCommand->setEnabled(note != nullptr);
+    myRemoveNoteCommand->setEnabled(pos || barline || hasSelection);
     myRemovePositionCommand->setEnabled(pos || barline || hasSelection);
 
     myChordNameCommand->setChecked(

--- a/source/app/powertabeditor.cpp
+++ b/source/app/powertabeditor.cpp
@@ -746,7 +746,7 @@ void PowerTabEditor::shiftBackward()
                         location.getSystemIndex());
 }
 
-void PowerTabEditor::removeNote()
+void PowerTabEditor::removeCurrentPosition()
 {
 	auto location = getLocation();
     bool isNote = location.getNote();
@@ -2028,7 +2028,7 @@ void PowerTabEditor::createCommands()
 #endif
     myRemoveNoteCommand = new Command(tr("Remove Note"), "Position.RemoveNote",
                                       QKeySequence::Delete, this);
-    connect(myRemoveNoteCommand, SIGNAL(triggered()), this, SLOT(removeNote()));
+    connect(myRemoveNoteCommand, SIGNAL(triggered()), this, SLOT(removeCurrentPosition()));
 
     myRemovePositionCommand = new Command(tr("Remove Position"),
                                           "Position.RemovePosition",

--- a/source/app/powertabeditor.h
+++ b/source/app/powertabeditor.h
@@ -161,7 +161,7 @@ private slots:
     /// Moves all positions after the current location backwards.
     void shiftBackward();
     /// Deletes the current note.
-    void removeNote();
+    void removeCurrentPosition();
     /// Deletes the currently-selected positions.
     void removeSelectedPositions();
     /// Moves the caret to a specific barline.


### PR DESCRIPTION
Hi, 

I have tried to fix issue #202 (as first step for fixing #220). I have modified `PowerTabEditor.removeNote` to a more generic `removeCurrentPosition` which choose if delete a single note (only if caret is on a note) or all the selected positions (so if I am on a rest position, I remove it). 

I hope it goes well!