### PR TITLE
Add dependency for copying ptedata files during build.

### DIFF
--- a/source/build/CMakeLists.txt
+++ b/source/build/CMakeLists.txt
@@ -28,3 +28,5 @@ pte_executable(
     PLUGINS
         ${QT5_PLUGINS}
 )
+
+add_dependencies(powertabeditor ptedata)


### PR DESCRIPTION
Previously there was no dependency between `powertabeditor` and `ptedata` meaning that data files (e.g. `tunings.json` in this case) would not copy automatically during the build, causing runtime errors due to expecting files that did not exist.

In my case the app would crash on close - since the `data/` folder did not exist in `build/bin/` it defaulted to creating an empty `tunings.json` in in AppData.
But since this file was empty it would throw an exception whilst parsing (this bubbled up at close since the load was async - the exception only threw when `TuningDictionary::ensureLoaded` tried to ensure the set of tunings was loaded).

This was building on Windows with VS2019.

One question this brings up is how should an empty/non existent `tunings.json` file be handled - should an empty but valid one be created? Or is it assumed that it'll always be present and if not it'll be fire and brimstone and so forth 😄 