### PR TITLE
Add Bulk Exporter

### DIFF
--- a/source/app/powertabeditor.cpp
+++ b/source/app/powertabeditor.cpp
@@ -99,6 +99,7 @@
 #include <dialogs/artificialharmonicdialog.h>
 #include <dialogs/barlinedialog.h>
 #include <dialogs/benddialog.h>
+#include <dialogs/bulkconverterdialog.h>
 #include <dialogs/chordnamedialog.h>
 #include <dialogs/directiondialog.h>
 #include <dialogs/dynamicdialog.h>
@@ -508,6 +509,12 @@ void PowerTabEditor::printDocument()
         return;
 
     getScoreArea()->print(printer);
+}
+
+void PowerTabEditor::bulkConverter()
+{
+    BulkConverterDialog dialog(this, myFileFormatManager);
+    dialog.exec();
 }
 
 void PowerTabEditor::printPreview()
@@ -1578,7 +1585,7 @@ void PowerTabEditor::editLeftHandFingering()
         LeftHandFingeringDialog dialog(this);
         if (dialog.exec() == QDialog::Accepted)
         {
-            myUndoManager->push(new AddLeftHandFingering(location, 
+            myUndoManager->push(new AddLeftHandFingering(location,
                                 dialog.getLeftHandFingering()),
                                 location.getSystemIndex());
         }
@@ -1916,6 +1923,12 @@ void PowerTabEditor::createCommands()
         tr("Print Preview..."), "File.PrintPreview", QKeySequence(), this);
     connect(myPrintPreviewCommand, &QAction::triggered, this,
             &PowerTabEditor::printPreview);
+
+    myBulkConverterCommand = new Command(tr("Bulk Converter"),
+                                        "File.BulkConverter",
+                                        QKeySequence(), this);
+    connect(myBulkConverterCommand, &QAction::triggered, this,
+            &PowerTabEditor::bulkConverter);
 
     myEditShortcutsCommand = new Command(tr("Customize Shortcuts..."),
                                          "File.CustomizeShortcuts",
@@ -2264,7 +2277,7 @@ void PowerTabEditor::createCommands()
                                Qt::SHIFT + Qt::Key_Left, this);
     connect(myRemoveDotCommand, &QAction::triggered, this, &PowerTabEditor::removeDot);
 
-    myLeftHandFingeringCommand = new Command(tr("Left Hand Fingering..."), 
+    myLeftHandFingeringCommand = new Command(tr("Left Hand Fingering..."),
                                              "Notes.LeftHandFingering",
                                              QKeySequence(), this,
                                              QStringLiteral(u":images/lefthandfingering.png"));
@@ -2639,7 +2652,7 @@ void PowerTabEditor::createCommands()
             &PowerTabEditor::editViewFilters);
 
     // Window Menu commands.
-    
+
 #ifdef Q_OS_MAC
     // NextChild is Command-{ on OS X, so use the more conventional Control-Tab
     // to match Safari, Finder, etc.
@@ -2649,7 +2662,7 @@ void PowerTabEditor::createCommands()
     QKeySequence next_tab_seq = QKeySequence::NextChild;
     QKeySequence prev_tab_seq = QKeySequence::PreviousChild;
 #endif
-    
+
     myNextTabCommand = new Command(tr("Next Tab"), "Window.NextTab",
                                    next_tab_seq, this);
     connect(myNextTabCommand, &QAction::triggered, [=]() {
@@ -2851,6 +2864,8 @@ void PowerTabEditor::createMenus()
     myFileMenu->addAction(myPrintPreviewCommand);
     myFileMenu->addSeparator();
     myRecentFilesMenu = myFileMenu->addMenu(tr("Recent Files"));
+    myFileMenu->addSeparator();
+    myFileMenu->addAction(myBulkConverterCommand);
     myFileMenu->addSeparator();
     myFileMenu->addAction(myEditShortcutsCommand);
     myFileMenu->addAction(myEditPreferencesCommand);

--- a/source/app/powertabeditor.cpp
+++ b/source/app/powertabeditor.cpp
@@ -1924,7 +1924,7 @@ void PowerTabEditor::createCommands()
     connect(myPrintPreviewCommand, &QAction::triggered, this,
             &PowerTabEditor::printPreview);
 
-    myBulkConverterCommand = new Command(tr("Bulk Converter"),
+    myBulkConverterCommand = new Command(tr("Bulk Converter..."),
                                         "File.BulkConverter",
                                         QKeySequence(), this);
     connect(myBulkConverterCommand, &QAction::triggered, this,

--- a/source/app/powertabeditor.h
+++ b/source/app/powertabeditor.h
@@ -14,7 +14,7 @@
   * You should have received a copy of the GNU General Public License
   * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-  
+
 #ifndef APP_POWERTABEDITOR_H
 #define APP_POWERTABEDITOR_H
 
@@ -77,6 +77,9 @@ private slots:
 
     /// Prints the current document.
     void printDocument();
+
+    /// Bulk conversion tool
+    void bulkConverter();
 
     /// Displays a preview of the current document.
     void printPreview();
@@ -448,6 +451,7 @@ private:
     Command *mySaveAsCommand;
     Command *myPrintCommand;
     Command *myPrintPreviewCommand;
+    Command *myBulkConverterCommand;
     QMenu *myRecentFilesMenu;
     Command *myEditShortcutsCommand;
     Command *myEditPreferencesCommand;
@@ -482,7 +486,7 @@ private:
     Command *myPrevPositionCommand;
     Command *myNextStringCommand;
     Command *myPrevStringCommand;
-    Command *myLastPositionCommand;    
+    Command *myLastPositionCommand;
     Command *myNextStaffCommand;
     Command *myPrevStaffCommand;
     Command *myNextBarCommand;

--- a/source/dialogs/CMakeLists.txt
+++ b/source/dialogs/CMakeLists.txt
@@ -6,6 +6,7 @@ set( srcs
     artificialharmonicdialog.cpp
     barlinedialog.cpp
     benddialog.cpp
+    bulkconverterdialog.cpp
     chordnamedialog.cpp
     crashdialog.cpp
     directiondialog.cpp
@@ -41,6 +42,7 @@ set( headers
     artificialharmonicdialog.h
     barlinedialog.h
     benddialog.h
+    bulkconverterdialog.h
     chordnamedialog.h
     crashdialog.h
     directiondialog.h
@@ -76,6 +78,7 @@ set( moc_headers
     artificialharmonicdialog.h
     barlinedialog.h
     benddialog.h
+    bulkconverterdialog.h
     chordnamedialog.h
     crashdialog.h
     directiondialog.h
@@ -104,6 +107,7 @@ set( forms
     artificialharmonicdialog.ui
     barlinedialog.ui
     benddialog.ui
+    bulkconverterdialog.ui
     chordnamedialog.ui
     crashdialog.ui
     directiondialog.ui

--- a/source/dialogs/bulkconverterdialog.cpp
+++ b/source/dialogs/bulkconverterdialog.cpp
@@ -1,0 +1,236 @@
+/*
+  * Copyright (C) 2020 Simon Symeonidis
+  *
+  * This program is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 3 of the License, or
+  * (at your option) any later version.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "bulkconverterdialog.h"
+#include "ui_bulkconverterdialog.h"
+
+#include "formats/powertab/common.h"
+
+#include <app/paths.h>
+#include <score/score.h>
+
+#include <QFileDialog>
+#include <QFileInfo>
+#include <QDebug>
+#include <QThread>
+
+std::optional<std::string> convertFile(const boost::filesystem::path& src,
+                                       const boost::filesystem::path& dst,
+                                       std::unique_ptr<FileFormatManager>& ffm)
+{
+    QFileInfo fileInfo(QString::fromStdString(src.string()));
+    std::optional<FileFormat> format = ffm->findFormat(
+                fileInfo.suffix().toStdString());
+
+    if (!format) return "bad format";
+
+    Score score;
+    try
+    {
+        ffm->importFile(score, src, *format);
+    }
+    catch (const std::exception &e)
+    {
+        return "could not import file: " + src.string();
+    }
+
+    try
+    {
+      ffm->exportFile(score, dst, FileFormat(getPowerTabFileFormat()));
+    }
+    catch (const std::exception &e)
+    {
+        return "could not export file: " + dst.string();
+    }
+
+    return std::nullopt;
+}
+
+BulkConverterWorker::BulkConverterWorker(boost::filesystem::path& source,
+                                         boost::filesystem::path& destination,
+                                         bool dryRun,
+                                         std::unique_ptr<FileFormatManager>& fileFormatManager)
+  : QObject(), mySrc(source), myDst(destination), myDryRun(dryRun),
+    myFileCount(0), myFileFormatManager(fileFormatManager)
+{
+}
+
+BulkConverterWorker::~BulkConverterWorker()
+{
+}
+
+void BulkConverterWorker::walkAndConvert()
+{
+    std::vector<boost::filesystem::path> children;
+    const std::string basePath = mySrc.string();
+
+    children.emplace_back(mySrc);
+
+    do {
+        boost::filesystem::path p = children.back();
+        children.pop_back();
+
+        if (!boost::filesystem::is_directory(p)) continue;
+
+        auto dir_it = boost::filesystem::directory_iterator(p);
+
+        for(auto& entry : boost::make_iterator_range(dir_it, {})) {
+            if (boost::filesystem::is_directory(entry)) {
+               children.emplace_back(entry);
+               continue;
+            }
+
+            // TODO: this should probably handle any supported format.
+            //   check to see if there is a list of file formats
+            //   like this
+            if (!(boost::filesystem::is_regular_file(entry) &&
+                  boost::filesystem::extension(entry) == ".ptb"))
+                continue;
+
+            myFileCount++;
+
+            auto filePath = entry.path().string();
+            const size_t pos = filePath.find(basePath);
+            if (pos != std::string::npos)
+                filePath.erase(pos, basePath.length());
+
+            auto toPath = myDst / boost::filesystem::path(filePath);
+            toPath.replace_extension("pt2");
+
+            if (myDryRun) continue;
+
+            auto destBaseDir = toPath.parent_path();
+            if (!boost::filesystem::exists(destBaseDir))
+                boost::filesystem::create_directory(destBaseDir);
+
+            std::optional<std::string> error = convertFile(entry, toPath, myFileFormatManager);
+            if (error != std::nullopt) {
+                QString err = QString::fromStdString(error.value());
+                emit errorMessage("error processing file: " + err);
+            }
+
+            emit progress((int) myFileCount);
+        }
+    } while (!children.empty());
+
+    emit done();
+}
+
+BulkConverterDialog::BulkConverterDialog(QWidget *parent,
+                                         std::unique_ptr<FileFormatManager>& manager)
+  : QDialog(parent), ui(new Ui::BulkConverterDialog),
+    myBulkWorkerThread(nullptr), myBulkConverterWorker(nullptr),
+    myFileFormatManager(manager)
+{
+    ui->setupUi(this);
+
+    auto flags = windowFlags();
+    setWindowFlags(flags | Qt::WindowStaysOnTopHint);
+
+    connect(ui->fileLocatorSource, &QAbstractButton::clicked, [=]() {
+        setPath(ui->sourcePathEdit);
+    });
+
+    connect(ui->fileLocatorDestination, &QAbstractButton::clicked, [=]() {
+        setPath(ui->destinationPathEdit);
+    });
+
+    connect(ui->convertButton, &QAbstractButton::clicked, [=](){ convert(); });
+
+    connect(ui->exitButton, &QAbstractButton::clicked, this, &QDialog::reject);
+}
+
+BulkConverterDialog::~BulkConverterDialog()
+{
+    if (myBulkWorkerThread) {
+        myBulkWorkerThread->quit();
+        myBulkWorkerThread->wait();
+    }
+    delete ui;
+}
+
+void BulkConverterDialog::setPath(QLineEdit *edit)
+{
+    auto dialogOptions = QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks;
+    QString path = QFileDialog::getExistingDirectory(
+        this, tr("Directory To Convert"), QDir::currentPath(), dialogOptions);
+
+    edit->setText(path);
+    QString src = ui->sourcePathEdit->text();
+    QString dst = ui->destinationPathEdit->text();
+    const bool bothEditsHaveValues = !src.isEmpty() && !dst.isEmpty();
+    ui->convertButton->setEnabled(bothEditsHaveValues);
+}
+
+void BulkConverterDialog::convert()
+{
+    ui->convertButton->setEnabled(false);
+
+    boost::filesystem::path src = Paths::fromQString(ui->sourcePathEdit->text());
+    boost::filesystem::path dst = Paths::fromQString(ui->destinationPathEdit->text());
+
+    {
+        // set default max.
+        BulkConverterWorker bcw(src, dst, true, myFileFormatManager);
+        bcw.walkAndConvert();
+        const std::size_t fileCountToConvert = bcw.fileCount();
+        ui->progressBar->setMaximum((int) fileCountToConvert);
+        ui->progressBar->setValue(0);
+    }
+
+    // create thread to offload work in the background, such that we can
+    // update the progress bar with each step informing the user of the
+    // current state of bulk conversion.
+    myBulkWorkerThread = new QThread;
+    myBulkConverterWorker = new BulkConverterWorker(src, dst, false, myFileFormatManager);
+    myBulkConverterWorker->moveToThread(myBulkWorkerThread);
+
+    connect(myBulkWorkerThread, &QThread::started,
+            myBulkConverterWorker, &BulkConverterWorker::walkAndConvert);
+
+    connect(myBulkWorkerThread, &QThread::finished,
+            myBulkWorkerThread, &QObject::deleteLater);
+
+    connect(myBulkConverterWorker, &BulkConverterWorker::progress,
+            this, &BulkConverterDialog::progress);
+
+    connect(myBulkConverterWorker, &BulkConverterWorker::done,
+            myBulkConverterWorker, &QObject::deleteLater);
+
+    connect(myBulkConverterWorker, &BulkConverterWorker::done,
+            this, &BulkConverterDialog::enableConvertButton);
+
+    connect(myBulkConverterWorker, &BulkConverterWorker::errorMessage,
+            this, &BulkConverterDialog::consumeErrorMessage);
+
+    myBulkWorkerThread->start();
+}
+
+void BulkConverterDialog::progress(int pos)
+{
+    ui->progressBar->setValue(pos);
+}
+
+void BulkConverterDialog::enableConvertButton(void)
+{
+    ui->convertButton->setEnabled(true);
+}
+
+void BulkConverterDialog::consumeErrorMessage(QString error)
+{
+    ui->logger->appendPlainText(error);
+}

--- a/source/dialogs/bulkconverterdialog.h
+++ b/source/dialogs/bulkconverterdialog.h
@@ -1,0 +1,91 @@
+/*
+  * Copyright (C) 2020 Simon Symeonidis
+  *
+  * This program is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 3 of the License, or
+  * (at your option) any later version.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef DIALOGS_BULKCONVERTERDIALOG_H
+#define DIALOGS_BULKCONVERTERDIALOG_H
+
+#include <QDialog>
+#include <QLineEdit>
+#include <QObject>
+#include <QThread>
+
+#include <boost/filesystem.hpp>
+#include <boost/range/iterator_range.hpp>
+
+#include <formats/fileformatmanager.h>
+
+#include <cstddef>
+
+namespace Ui {
+    class BulkConverterDialog;
+}
+
+class BulkConverterWorker : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit BulkConverterWorker(boost::filesystem::path& source,
+                                 boost::filesystem::path& destination,
+                                 bool dryRun,
+                                 std::unique_ptr<FileFormatManager>& fileFormatManager);
+    ~BulkConverterWorker();
+
+    inline void setFileCount(std::size_t f) { myFileCount = f; }
+    inline std::size_t fileCount() { return myFileCount; }
+
+public slots:
+    void walkAndConvert();
+
+signals:
+    void progress(int pos);
+    void done(void);
+    void errorMessage(QString error);
+
+private:
+    boost::filesystem::path mySrc;
+    boost::filesystem::path myDst;
+    bool myDryRun;
+    std::size_t myFileCount;
+    std::unique_ptr<FileFormatManager>& myFileFormatManager;
+};
+
+class BulkConverterDialog : public QDialog {
+    Q_OBJECT
+
+public:
+    explicit BulkConverterDialog(QWidget *parent,
+                                 std::unique_ptr<FileFormatManager>& fileFormatManager);
+    ~BulkConverterDialog();
+
+public slots:
+    void progress(int pos);
+    void consumeErrorMessage(QString error);
+
+private slots:
+    void setPath(QLineEdit*);
+    void convert();
+    void enableConvertButton(void);
+
+private:
+    Ui::BulkConverterDialog *ui;
+    QThread* myBulkWorkerThread;
+    BulkConverterWorker* myBulkConverterWorker;
+    std::unique_ptr<FileFormatManager>& myFileFormatManager;;
+};
+
+#endif

--- a/source/dialogs/bulkconverterdialog.h
+++ b/source/dialogs/bulkconverterdialog.h
@@ -54,7 +54,7 @@ public slots:
 signals:
     void progress(int pos);
     void done(void);
-    void errorMessage(QString error);
+    void message(QString error);
 
 private:
     boost::filesystem::path mySrc;
@@ -74,7 +74,7 @@ public:
 
 public slots:
     void progress(int pos);
-    void consumeErrorMessage(QString error);
+    void consumeMessage(QString message);
 
 private slots:
     void setPath(QLineEdit*);
@@ -85,7 +85,7 @@ private:
     Ui::BulkConverterDialog *ui;
     QThread* myBulkWorkerThread;
     BulkConverterWorker* myBulkConverterWorker;
-    std::unique_ptr<FileFormatManager>& myFileFormatManager;;
+    std::unique_ptr<FileFormatManager>& myFileFormatManager;
 };
 
 #endif

--- a/source/dialogs/bulkconverterdialog.ui
+++ b/source/dialogs/bulkconverterdialog.ui
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>BulkConverterDialog</class>
+ <widget class="QDialog" name="BulkConverterDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>356</width>
+    <height>299</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <widget class="QProgressBar" name="progressBar">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>110</y>
+     <width>331</width>
+     <height>23</height>
+    </rect>
+   </property>
+   <property name="value">
+    <number>0</number>
+   </property>
+   <property name="textVisible">
+    <bool>true</bool>
+   </property>
+  </widget>
+  <widget class="QPushButton" name="fileLocatorSource">
+   <property name="geometry">
+    <rect>
+     <x>299</x>
+     <y>30</y>
+     <width>41</width>
+     <height>21</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>...</string>
+   </property>
+  </widget>
+  <widget class="QLineEdit" name="sourcePathEdit">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>30</y>
+     <width>281</width>
+     <height>21</height>
+    </rect>
+   </property>
+  </widget>
+  <widget class="QLabel" name="sourceDirLabel">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>10</y>
+     <width>111</width>
+     <height>16</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Source Directory</string>
+   </property>
+  </widget>
+  <widget class="QLineEdit" name="destinationPathEdit">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>80</y>
+     <width>281</width>
+     <height>21</height>
+    </rect>
+   </property>
+  </widget>
+  <widget class="QLabel" name="destinationPathLabel">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>60</y>
+     <width>281</width>
+     <height>16</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Destination Directory</string>
+   </property>
+  </widget>
+  <widget class="QPushButton" name="fileLocatorDestination">
+   <property name="geometry">
+    <rect>
+     <x>300</x>
+     <y>80</y>
+     <width>41</width>
+     <height>21</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>...</string>
+   </property>
+  </widget>
+  <widget class="QPlainTextEdit" name="logger">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>180</y>
+     <width>331</width>
+     <height>101</height>
+    </rect>
+   </property>
+   <property name="readOnly">
+    <bool>true</bool>
+   </property>
+  </widget>
+  <widget class="QPushButton" name="convertButton">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>150</y>
+     <width>241</width>
+     <height>21</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>&amp;Convert</string>
+   </property>
+  </widget>
+  <widget class="QPushButton" name="exitButton">
+   <property name="geometry">
+    <rect>
+     <x>260</x>
+     <y>150</y>
+     <width>80</width>
+     <height>21</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>E&amp;xit</string>
+   </property>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/source/dialogs/bulkconverterdialog.ui
+++ b/source/dialogs/bulkconverterdialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Dialog</string>
+   <string>Bulk Converter</string>
   </property>
   <widget class="QProgressBar" name="progressBar">
    <property name="geometry">
@@ -34,8 +34,6 @@
     <rect>
      <x>299</x>
      <y>30</y>
-     <width>41</width>
-     <height>21</height>
     </rect>
    </property>
    <property name="text">
@@ -99,8 +97,6 @@
     <rect>
      <x>300</x>
      <y>80</y>
-     <width>41</width>
-     <height>21</height>
     </rect>
    </property>
    <property name="text">

--- a/source/formats/fileformatmanager.cpp
+++ b/source/formats/fileformatmanager.cpp
@@ -14,7 +14,7 @@
   * You should have received a copy of the GNU General Public License
   * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-  
+
 #include "fileformatmanager.h"
 
 #include <formats/gp7/gp7importer.h>
@@ -120,4 +120,10 @@ void FileFormatManager::exportFile(const Score &score,
     }
 
     throw std::runtime_error("Unknown file format");
+}
+
+bool FileFormatManager::extensionImportSupported(const std::string& extension) const {
+    for (auto const& importer : myImporters)
+        if (importer->fileFormat().contains(extension)) return true;
+    return false;
 }

--- a/source/formats/fileformatmanager.h
+++ b/source/formats/fileformatmanager.h
@@ -14,7 +14,7 @@
   * You should have received a copy of the GNU General Public License
   * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-  
+
 #ifndef FORMATS_FILEFORMATMANAGER_H
 #define FORMATS_FILEFORMATMANAGER_H
 
@@ -55,6 +55,8 @@ public:
     void exportFile(const Score &score, const boost::filesystem::path &filename,
                     const FileFormat &format);
 
+    // Checks to see if there is an importer for the designated extension
+    bool extensionImportSupported(const std::string& extension) const;
 private:
     template <typename Importer>
     void registerImporter();


### PR DESCRIPTION
Here's a mock. I'm almost done with a draft of the implementation. I was thinking of having the code replicate the src fs tree into the destination tree. 

ie: source looks like this: 

```
src/a/1.ptb
src/b/2.ptb
src/c/3.ptb
src/c/d/4.ptb
```

into:

```
dest/a/1.pt2
dest/b/2.pt2
dest/c/3.pt2
dest/c/d/4.pt2
```

What this implies is if src is dest, the files would be generated alongside in the same directory. Is this sane behavior? 

Also here's a mock: 
![screen](https://user-images.githubusercontent.com/505688/83361406-be184d00-a356-11ea-9fd9-1717592a4f2e.png)

The last box should show messages if some file could not be read, or something weird happens.

Does this course of development seem ok so far? Will implement the actual conversion algo today probably.

* * * 

TODO (to complete this PR):
- [x] reconsider directory walking implementation?
- [x] rename bulk convert
- [x] add informative error message on stdout + edit box on files which fail to be converted