### PR TITLE
add check for complex alternate endings

### DIFF
--- a/source/score/utils/repeatindexer.cpp
+++ b/source/score/utils/repeatindexer.cpp
@@ -137,7 +137,7 @@ RepeatIndexer::RepeatIndexer(const Score &score)
     // The start of the score can always act as a repeat start bar.
     repeats.push(SystemLocation(0, 0));
 
-    int systemIndex = 0;
+    unsigned int systemIndex = 0;
     for (const System &system : score.getSystems())
     {
         for (const Barline &bar : system.getBarlines())
@@ -174,40 +174,9 @@ RepeatIndexer::RepeatIndexer(const Score &score)
                     activeRepeat.getAlternateEndingCount() >=
                         activeRepeat.getTotalRepeatCount())
                 {
-                    // Check for following repeat endings that means we're not
-                    // done scanning all alternate endings of this repeat.
-                    bool doneScanning = false;
-                    bool repeatDone = true;
-                    for (size_t i = systemIndex; i < score.getSystems().size(); ++i)
-                    {
-                        for (const Barline &barCheck : score.getSystems()[i].getBarlines())
-                        {
-                            if (barCheck.getPosition() > bar.getPosition() ||
-                                i > systemIndex)
-                            {
-                                // If we get to a repeat end first then the repeated
-                                // section is not finished.
-                                if (barCheck.getBarType() == Barline::RepeatEnd)
-                                {
-                                    doneScanning = true;
-                                    repeatDone = false;
-                                    break;
-                                }
-                                // If we get to a repeat start first then the
-                                // repeated section must be finished.
-                                else if (barCheck.getBarType() == Barline::RepeatStart)
-                                {
-                                    doneScanning = true;
-                                    break;
-                                }
-                            }
-                        }
-                        if (doneScanning)
-                            break;
-                    }
                     // If no following repeat endings then we're done with this
                     // repeat.
-                    if (repeatDone)
+                    if (!this->nextRepeatIsEnd(score, systemIndex, bar))
                     {
                         if (bar.getBarType() == Barline::RepeatEnd)
                         {
@@ -280,4 +249,32 @@ boost::iterator_range<RepeatIndexer::RepeatedSectionIterator>
 RepeatIndexer::getRepeats() const
 {
     return boost::make_iterator_range(myRepeats);
+}
+
+bool RepeatIndexer::nextRepeatIsEnd(
+    const Score &score, const int systemIndex, const Barline &bar) const
+{
+    for (size_t i = systemIndex; i < score.getSystems().size(); ++i)
+    {
+        for (const Barline &barCheck : score.getSystems()[i].getBarlines())
+        {
+            if (barCheck.getPosition() > bar.getPosition() ||
+                i > systemIndex)
+            {
+                // If we get to a repeat end first then the repeated
+                // section is not finished.
+                if (barCheck.getBarType() == Barline::RepeatEnd)
+                {
+                    return true;
+                }
+                // If we get to a repeat start first then the
+                // repeated section must be finished.
+                else if (barCheck.getBarType() == Barline::RepeatStart)
+                {
+                    return false;
+                }
+            }
+        }
+    }
+    return false;
 }

--- a/source/score/utils/repeatindexer.cpp
+++ b/source/score/utils/repeatindexer.cpp
@@ -174,8 +174,41 @@ RepeatIndexer::RepeatIndexer(const Score &score)
                     activeRepeat.getAlternateEndingCount() >=
                         activeRepeat.getTotalRepeatCount())
                 {
-                    myRepeats.insert(activeRepeat);
-                    repeats.pop();
+                    // Check for following repeat endings that means we're not
+                    // done scanning all alternate endings of this repeat.
+                    bool done = true;
+                    for (const Barline &barCheck : system.getBarlines())
+                    {
+                        if (barCheck.getPosition() > bar.getPosition())
+                        {
+                            // If we get to a repeat end first then the repeated
+                            // section is not finished.
+                            if (barCheck.getBarType() == Barline::RepeatEnd)
+                            {
+                                done = false;
+                                break;
+                            }
+                            // If we get to a repeat start first then the
+                            // repeated section must be finished.
+                            else if (barCheck.getBarType() == Barline::RepeatStart)
+                            {
+                                break;
+                            }
+                        }
+                    }
+                    // If no following repeat endings then we're done with this
+                    // repeat.
+                    if (done)
+                    {
+                        if (bar.getBarType() == Barline::RepeatEnd)
+                        {
+                            activeRepeat.addRepeatEndBar(
+                                SystemLocation(systemIndex, bar.getPosition()),
+                                bar.getRepeatCount());
+                        }
+                        myRepeats.insert(activeRepeat);
+                        repeats.pop();
+                    }
                 }
             }
 

--- a/source/score/utils/repeatindexer.cpp
+++ b/source/score/utils/repeatindexer.cpp
@@ -176,29 +176,38 @@ RepeatIndexer::RepeatIndexer(const Score &score)
                 {
                     // Check for following repeat endings that means we're not
                     // done scanning all alternate endings of this repeat.
-                    bool done = true;
-                    for (const Barline &barCheck : system.getBarlines())
+                    bool doneScanning = false;
+                    bool repeatDone = true;
+                    for (size_t i = systemIndex; i < score.getSystems().size(); ++i)
                     {
-                        if (barCheck.getPosition() > bar.getPosition())
+                        for (const Barline &barCheck : score.getSystems()[i].getBarlines())
                         {
-                            // If we get to a repeat end first then the repeated
-                            // section is not finished.
-                            if (barCheck.getBarType() == Barline::RepeatEnd)
+                            if (barCheck.getPosition() > bar.getPosition() ||
+                                i > systemIndex)
                             {
-                                done = false;
-                                break;
-                            }
-                            // If we get to a repeat start first then the
-                            // repeated section must be finished.
-                            else if (barCheck.getBarType() == Barline::RepeatStart)
-                            {
-                                break;
+                                // If we get to a repeat end first then the repeated
+                                // section is not finished.
+                                if (barCheck.getBarType() == Barline::RepeatEnd)
+                                {
+                                    doneScanning = true;
+                                    repeatDone = false;
+                                    break;
+                                }
+                                // If we get to a repeat start first then the
+                                // repeated section must be finished.
+                                else if (barCheck.getBarType() == Barline::RepeatStart)
+                                {
+                                    doneScanning = true;
+                                    break;
+                                }
                             }
                         }
+                        if (doneScanning)
+                            break;
                     }
                     // If no following repeat endings then we're done with this
                     // repeat.
-                    if (done)
+                    if (repeatDone)
                     {
                         if (bar.getBarType() == Barline::RepeatEnd)
                         {

--- a/source/score/utils/repeatindexer.h
+++ b/source/score/utils/repeatindexer.h
@@ -26,6 +26,7 @@
 #include <unordered_map>
 
 class AlternateEnding;
+class Barline;
 class Score;
 class System;
 
@@ -89,6 +90,8 @@ public:
 
     /// Returns a list of the repeated sections in the score.
     boost::iterator_range<RepeatedSectionIterator> getRepeats() const;
+    bool nextRepeatIsEnd(const Score &score, const int systemIndex,
+                         const Barline &bar) const;
 
 private:
     std::set<RepeatedSection> myRepeats;


### PR DESCRIPTION
### Description of Change(s)
The original logic in `RepeatIndexer` did not check for additional repeat ending bar lines once the number of alternate endings encountered was equal or greater than the number of repeats. I have added a check for that (similar to `systemrenderer::drawAlternateEndings`) as well as adding those ending bar lines to the repeat.

A bit of a tangent, but the attached file ([alternate_endings2.zip](https://github.com/powertab/powertabeditor/files/5178486/alternate_endings2.zip)) has the original score from the issue plus some other tests I thought up quickly. Everything except the 4th system works as I expect with this patch. I'm not sure if that one case is really related to this, or maybe it's just a poor choice of typesetting that doesn't need to be handled.

### Fixes Issue(s)
- #293 