### PR TITLE
Get rid of some build warnings

### DIFF
--- a/source/dialogs/chordnamedialog.cpp
+++ b/source/dialogs/chordnamedialog.cpp
@@ -58,8 +58,8 @@ ChordNameDialog::ChordNameDialog(QWidget *parent)
     myTonicKeys->addButton(ui->tonicGButton, ChordName::G);
     myTonicKeys->addButton(ui->tonicAButton, ChordName::A);
     myTonicKeys->addButton(ui->tonicBButton, ChordName::B);
-    connect(myTonicKeys, qOverload<int>(&QButtonGroup::buttonClicked), this,
-            &ChordNameDialog::onTonicChanged);
+    connect(myTonicKeys, &QButtonGroup::idClicked,
+            this, &ChordNameDialog::onTonicChanged);
 
     myBassKeys = new QButtonGroup(this);
     myBassKeys->addButton(ui->bassCButton, ChordName::C);
@@ -69,8 +69,8 @@ ChordNameDialog::ChordNameDialog(QWidget *parent)
     myBassKeys->addButton(ui->bassGButton, ChordName::G);
     myBassKeys->addButton(ui->bassAButton, ChordName::A);
     myBassKeys->addButton(ui->bassBButton, ChordName::B);
-    connect(myBassKeys, qOverload<int>(&QButtonGroup::buttonClicked), this,
-            &ChordNameDialog::updateState);
+    connect(myBassKeys, &QButtonGroup::idClicked,
+            this, &ChordNameDialog::updateState);
 
     connect(ui->formulaListWidget, &QListWidget::currentRowChanged, this,
             &ChordNameDialog::updateState);

--- a/source/painters/scoreinforenderer.cpp
+++ b/source/painters/scoreinforenderer.cpp
@@ -115,6 +115,8 @@ static void addAuthorText(QGraphicsItemGroup &group, QFont font,
                           const QColor &color, const QString &text, const double y,
                           bool right_align = false)
 {
+    (void) color;
+
     font.setPointSize(AUTHOR_SIZE);
 
     auto text_item = new QGraphicsTextItem(text);
@@ -232,7 +234,7 @@ static void renderLessonInfo(QGraphicsItemGroup &group, const QFont &font,
 
     if (!lesson_data.getSubtitle().empty())
     {
-        addCenteredText(group, font, SUBTITLE_SIZE, color, 
+        addCenteredText(group, font, SUBTITLE_SIZE, color,
                         QString::fromStdString(lesson_data.getSubtitle()));
     }
 

--- a/source/widgets/playback/playbackwidget.cpp
+++ b/source/widgets/playback/playbackwidget.cpp
@@ -129,7 +129,7 @@ PlaybackWidget::PlaybackWidget(const QAction &play_pause_command,
 
     ui->zoomComboBox->setValidator(new PercentageValidator(ui->zoomComboBox));
 
-    connect(myVoices, qOverload<int>(&QButtonGroup::buttonClicked), this,
+    connect(myVoices, &QButtonGroup::idClicked, this,
             &PlaybackWidget::activeVoiceChanged);
     connect(ui->speedSpinner,qOverload<int>(&QSpinBox::valueChanged), this,
             &PlaybackWidget::playbackSpeedChanged);


### PR DESCRIPTION
### Description of Change(s)
Simple quality of life fixes. Forces ignore on a unused function parameter, and updates the use of some Qt api things.

I am testing out to see that the Qt updates are not messing up the behavior by any way (but I think it's working properly with the quick manual tests I did)

### Fixes Issue(s)
- Removes some warnings when building
