### PR TITLE
Feature/add os and version information dialog

### DIFF
--- a/source/app/CMakeLists.txt
+++ b/source/app/CMakeLists.txt
@@ -1,27 +1,5 @@
 project( pteapp )
 
-set( _version ${PTE_VERSION} )
-
-# Get a version number for development builds.
-include( FindGit )
-if ( GIT_FOUND )
-    execute_process(
-        COMMAND ${GIT_EXECUTABLE} describe --tags --long --always
-        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-        OUTPUT_VARIABLE git_revision
-        ERROR_VARIABLE error_var
-        RESULT_VARIABLE result_var
-    )
-
-    if ( result_var EQUAL 0 )
-        string( STRIP "${git_revision}" git_revision )
-        set( _version ${git_revision} )
-    endif ()
-endif ()
-
-message( STATUS "Version number: ${_version}" )
-add_definitions( -DVERSION=${_version} )
-
 set( srcs
     appinfo.cpp
     caret.cpp

--- a/source/app/appinfo.cpp
+++ b/source/app/appinfo.cpp
@@ -15,6 +15,8 @@
   * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <sstream>
+
 #include "appinfo.h"
 
 #include <util/version.h>
@@ -45,13 +47,15 @@ namespace AppInfo
         return path;
     }
 
-    QString makeApplicationName(void)
+    std::string makeApplicationName(void)
     {
-        auto name = QString("%1 %2 Beta").arg(
-            APPLICATION_NAME,
-            APPLICATION_VERSION
-        );
+        std::stringstream ss;
 
-        return name + QString::fromStdString(Version::get());
+        ss << APPLICATION_NAME << " "
+           << APPLICATION_VERSION << " "
+           << "Beta "
+           << Version::get();
+
+        return ss.str();
     }
 }

--- a/source/app/appinfo.cpp
+++ b/source/app/appinfo.cpp
@@ -17,6 +17,8 @@
 
 #include "appinfo.h"
 
+#include <util/version.h>
+
 #include <QCoreApplication>
 #include <QtGlobal>
 
@@ -41,5 +43,15 @@ namespace AppInfo
         path += "/";
         path += relative_path;
         return path;
+    }
+
+    QString makeApplicationName(void)
+    {
+        auto name = QString("%1 %2 Beta").arg(
+            APPLICATION_NAME,
+            APPLICATION_VERSION
+        );
+
+        return name + QString::fromStdString(Version::get());
     }
 }

--- a/source/app/appinfo.h
+++ b/source/app/appinfo.h
@@ -19,6 +19,7 @@
 #define APP_APPINFO_H
 
 #include <string>
+#include <QString>
 
 namespace AppInfo
 {
@@ -34,6 +35,9 @@ namespace AppInfo
     /// Given a path relative to the location of the executable, return the full
     /// path.
     std::string getAbsolutePath(const char *relative_path);
+
+    /// Make application name with version
+    QString makeApplicationName(void);
 }
 
 #endif

--- a/source/app/appinfo.h
+++ b/source/app/appinfo.h
@@ -19,7 +19,6 @@
 #define APP_APPINFO_H
 
 #include <string>
-#include <QString>
 
 namespace AppInfo
 {
@@ -37,7 +36,7 @@ namespace AppInfo
     std::string getAbsolutePath(const char *relative_path);
 
     /// Make application name with version
-    QString makeApplicationName(void);
+    std::string makeApplicationName(void);
 }
 
 #endif

--- a/source/app/powertabeditor.cpp
+++ b/source/app/powertabeditor.cpp
@@ -145,6 +145,7 @@
 #include <score/voiceutils.h>
 
 #include <util/tostring.h>
+#include <util/version.h>
 
 #include <widgets/instruments/instrumentpanel.h>
 #include <widgets/mixer/mixer.h>
@@ -1914,7 +1915,7 @@ void PowerTabEditor::editViewFilters()
     }
 }
 
-void PowerTabEditor::info()
+void PowerTabEditor::info(void)
 {
     InfoDialog(this).exec();
 }
@@ -2012,9 +2013,7 @@ QString PowerTabEditor::getApplicationName() const
                 AppInfo::APPLICATION_NAME,
                 AppInfo::APPLICATION_VERSION);
 
-#ifdef VERSION
-    name += QString(" (v") + BOOST_STRINGIZE(VERSION) + ")";
-#endif
+    name += QString::fromStdString(Version::get());
 
     return name;
 }

--- a/source/app/powertabeditor.cpp
+++ b/source/app/powertabeditor.cpp
@@ -101,6 +101,7 @@
 #include <dialogs/fileinformationdialog.h>
 #include <dialogs/gotobarlinedialog.h>
 #include <dialogs/gotorehearsalsigndialog.h>
+#include <dialogs/infodialog.h>
 #include <dialogs/irregulargroupingdialog.h>
 #include <dialogs/keyboardsettingsdialog.h>
 #include <dialogs/keysignaturedialog.h>
@@ -1913,6 +1914,11 @@ void PowerTabEditor::editViewFilters()
     }
 }
 
+void PowerTabEditor::info()
+{
+    InfoDialog(this).exec();
+}
+
 bool PowerTabEditor::eventFilter(QObject *object, QEvent *event)
 {
     // Don't handle key presses during playback.
@@ -2846,6 +2852,11 @@ void PowerTabEditor::createCommands()
         QDesktopServices::openUrl(QUrl(AppInfo::BUG_TRACKER_URL));
     });
 
+    myInfoCommand = new Command(tr("App Info"), "Help.Info",
+                                QKeySequence(), this);
+
+    connect(myInfoCommand, &QAction::triggered, this, &PowerTabEditor::info);
+
     myMixerDockWidgetCommand =
         createCommandWrapper(myMixerDockWidget->toggleViewAction(),
                              "Window.Mixer", QKeySequence(), this);
@@ -3240,6 +3251,7 @@ void PowerTabEditor::createMenus()
     // Help menu.
     myHelpMenu = menuBar()->addMenu(tr("&Help"));
     myHelpMenu->addAction(myReportBugCommand);
+    myHelpMenu->addAction(myInfoCommand);
 }
 
 void PowerTabEditor::createToolBox()

--- a/source/app/powertabeditor.h
+++ b/source/app/powertabeditor.h
@@ -261,6 +261,8 @@ private slots:
     void showTuningDictionary();
     /// Shows a dialog to edit the score's view filters.
     void editViewFilters();
+    /// Opens the info dialog
+    void info();
 
 protected:
     /// Handle key presses for 0-9 when entering tab numbers.
@@ -624,6 +626,7 @@ private:
 
     QMenu *myHelpMenu;
     Command *myReportBugCommand;
+    Command *myInfoCommand;
 };
 
 #endif

--- a/source/app/powertabeditor.h
+++ b/source/app/powertabeditor.h
@@ -262,7 +262,7 @@ private slots:
     /// Shows a dialog to edit the score's view filters.
     void editViewFilters();
     /// Opens the info dialog
-    void info();
+    void info(void);
 
 protected:
     /// Handle key presses for 0-9 when entering tab numbers.

--- a/source/dialogs/CMakeLists.txt
+++ b/source/dialogs/CMakeLists.txt
@@ -15,6 +15,7 @@ set( srcs
     filterrulewidget.cpp
     gotobarlinedialog.cpp
     gotorehearsalsigndialog.cpp
+    infodialog.cpp
     irregulargroupingdialog.cpp
     lefthandfingeringdialog.cpp
     keyboardsettingsdialog.cpp
@@ -51,6 +52,7 @@ set( headers
     filterrulewidget.h
     gotobarlinedialog.h
     gotorehearsalsigndialog.h
+    infodialog.h
     irregulargroupingdialog.h
     keyboardsettingsdialog.h
     keysignaturedialog.h
@@ -85,6 +87,7 @@ set( moc_headers
     fileinformationdialog.h
     filterrulewidget.h
     gotorehearsalsigndialog.h
+    infodialog.h
     keyboardsettingsdialog.h
     keysignaturedialog.h
     lefthandfingeringdialog.h
@@ -116,6 +119,7 @@ set( forms
     filterrulewidget.ui
     gotobarlinedialog.ui
     gotorehearsalsigndialog.ui
+    infodialog.ui
     irregulargroupingdialog.ui
     keyboardsettingsdialog.ui
     keysignaturedialog.ui

--- a/source/dialogs/infodialog.cpp
+++ b/source/dialogs/infodialog.cpp
@@ -44,8 +44,8 @@ void InfoDialog::setInfo()
     const QString qname = QString::fromStdString(name);
 
     const auto developmentBinaryLocation =
-      QString("You can grab development binaries here:\n"
-              "  https://github.com/powertab/powertabeditor/actions");
+        QString(QObject::tr("You can grab development binaries here:\n"
+                            "  https://github.com/powertab/powertabeditor/actions"));
 
     const auto message = QString("%1\n\n%2").arg(
         qname,

--- a/source/dialogs/infodialog.cpp
+++ b/source/dialogs/infodialog.cpp
@@ -40,19 +40,6 @@ InfoDialog::InfoDialog(QWidget *parent) :
 
 void InfoDialog::setInfo()
 {
-  // TODO: this is copied from powertabeditor.cpp
-  // might be a good idea to have a util function
-  // to make the name
-  auto name = QString("%1 %2 Beta").arg(
-      AppInfo::APPLICATION_NAME,
-      AppInfo::APPLICATION_VERSION
-  );
-
-  // This should probably be in utils as well, so that we can get the
-  // version number that way, anywhere in the application
-#ifdef VERSION
-    name += QString(" (v") + BOOST_STRINGIZE(VERSION) + ")";
-#endif
-
-  ui->appInfo->setText(name);
+    auto name = AppInfo::makeApplicationName();
+    ui->appInfo->setText(name);
 }

--- a/source/dialogs/infodialog.cpp
+++ b/source/dialogs/infodialog.cpp
@@ -40,14 +40,15 @@ InfoDialog::InfoDialog(QWidget *parent) :
 
 void InfoDialog::setInfo()
 {
-    auto name = AppInfo::makeApplicationName();
+    const std::string name = AppInfo::makeApplicationName();
+    const QString qname = QString::fromStdString(name);
 
     const auto developmentBinaryLocation =
       QString("You can grab development binaries here:\n"
               "  https://github.com/powertab/powertabeditor/actions");
 
     const auto message = QString("%1\n\n%2").arg(
-        name,
+        qname,
         developmentBinaryLocation
     );
 

--- a/source/dialogs/infodialog.cpp
+++ b/source/dialogs/infodialog.cpp
@@ -1,0 +1,58 @@
+/*
+  * Copyright (C) 2021 Simon Symeonidis
+  *
+  * This program is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 3 of the License, or
+  * (at your option) any later version.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "infodialog.h"
+#include "ui_infodialog.h"
+
+#include <app/appinfo.h>
+
+#include <QClipboard>
+
+InfoDialog::InfoDialog(QWidget *parent) :
+  QDialog(parent),
+  ui(new Ui::InfoDialog)
+{
+    auto flags = windowFlags();
+    setWindowFlags(flags | Qt::WindowStaysOnTopHint);
+    ui->setupUi(this);
+
+    setInfo();
+
+    connect(ui->copyToClipboardButton, &QAbstractButton::clicked, [=]() {
+        QClipboard *clipboard = QApplication::clipboard();
+        clipboard->setText(ui->appInfo->toPlainText());
+    });
+}
+
+void InfoDialog::setInfo()
+{
+  // TODO: this is copied from powertabeditor.cpp
+  // might be a good idea to have a util function
+  // to make the name
+  auto name = QString("%1 %2 Beta").arg(
+      AppInfo::APPLICATION_NAME,
+      AppInfo::APPLICATION_VERSION
+  );
+
+  // This should probably be in utils as well, so that we can get the
+  // version number that way, anywhere in the application
+#ifdef VERSION
+    name += QString(" (v") + BOOST_STRINGIZE(VERSION) + ")";
+#endif
+
+  ui->appInfo->setText(name);
+}

--- a/source/dialogs/infodialog.cpp
+++ b/source/dialogs/infodialog.cpp
@@ -41,5 +41,15 @@ InfoDialog::InfoDialog(QWidget *parent) :
 void InfoDialog::setInfo()
 {
     auto name = AppInfo::makeApplicationName();
-    ui->appInfo->setText(name);
+
+    const auto developmentBinaryLocation =
+      QString("You can grab development binaries here:\n"
+              "  https://github.com/powertab/powertabeditor/actions");
+
+    const auto message = QString("%1\n\n%2").arg(
+        name,
+        developmentBinaryLocation
+    );
+
+    ui->appInfo->setText(message);
 }

--- a/source/dialogs/infodialog.h
+++ b/source/dialogs/infodialog.h
@@ -1,0 +1,41 @@
+/*
+  * Copyright (C) 2021 Simon Symeonidis
+  *
+  * This program is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 3 of the License, or
+  * (at your option) any later version.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef DIALOGS_INFODIALOG_H
+#define DIALOGS_INFODIALOG_H
+
+#include <QDialog>
+
+namespace Ui {
+  class InfoDialog;
+};
+
+class InfoDialog : public QDialog {
+  Q_OBJECT
+public:
+  explicit InfoDialog(QWidget *parent);
+  ~InfoDialog() {}
+
+private:
+  Ui::InfoDialog *ui;
+  void setInfo();
+
+private slots:
+signals:
+};
+
+#endif

--- a/source/dialogs/infodialog.ui
+++ b/source/dialogs/infodialog.ui
@@ -26,10 +26,10 @@
     <item row="0" column="0">
      <widget class="QTextEdit" name="appInfo">
       <property name="enabled">
-       <bool>false</bool>
+       <bool>true</bool>
       </property>
       <property name="readOnly">
-       <bool>false</bool>
+       <bool>true</bool>
       </property>
      </widget>
     </item>

--- a/source/dialogs/infodialog.ui
+++ b/source/dialogs/infodialog.ui
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>InfoDialog</class>
+ <widget class="QDialog" name="InfoDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>749</width>
+    <height>542</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Application Info</string>
+  </property>
+  <widget class="QWidget" name="gridLayoutWidget">
+   <property name="geometry">
+    <rect>
+     <x>9</x>
+     <y>9</y>
+     <width>731</width>
+     <height>521</height>
+    </rect>
+   </property>
+   <layout class="QGridLayout" name="gridLayout">
+    <item row="0" column="0">
+     <widget class="QTextEdit" name="appInfo">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="readOnly">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="0">
+     <widget class="QPushButton" name="copyToClipboardButton">
+      <property name="text">
+       <string>&amp;Copy to Clipboard</string>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/source/util/CMakeLists.txt
+++ b/source/util/CMakeLists.txt
@@ -1,5 +1,27 @@
 project( pteutil )
 
+set( _version ${PTE_VERSION} )
+
+# Get a version number for development builds.
+include( FindGit )
+if ( GIT_FOUND )
+    execute_process(
+        COMMAND ${GIT_EXECUTABLE} describe --tags --long --always
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+        OUTPUT_VARIABLE git_revision
+        ERROR_VARIABLE error_var
+        RESULT_VARIABLE result_var
+    )
+
+    if ( result_var EQUAL 0 )
+        string( STRIP "${git_revision}" git_revision )
+        set( _version ${git_revision} )
+    endif ()
+endif ()
+
+message( STATUS "Version number: ${_version}" )
+add_definitions( -DVERSION=${_version} )
+
 set( platform_srcs )
 if ( PLATFORM_OSX )
     set( platform_srcs settingstree_plist.mm )
@@ -7,6 +29,7 @@ endif ()
 
 set( srcs
     settingstree.cpp
+    version.cpp
 
     ${platform_srcs}
 )
@@ -16,6 +39,7 @@ set( headers
     settingstree.h
     tostring.h
     scopeexit.h
+    version.h
 )
 
 set( platform_depends )

--- a/source/util/CMakeLists.txt
+++ b/source/util/CMakeLists.txt
@@ -20,7 +20,7 @@ if ( GIT_FOUND )
 endif ()
 
 message( STATUS "Version number: ${_version}" )
-add_definitions( -DVERSION=${_version} )
+add_definitions( -DPTE_VERSION=${_version} )
 
 set( platform_srcs )
 if ( PLATFORM_OSX )

--- a/source/util/version.cpp
+++ b/source/util/version.cpp
@@ -1,0 +1,31 @@
+/*
+  * Copyright (C) 2020 Cameron White
+  * Copyright (C) 2021 Simon Symeonidis
+  *
+  * This program is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 3 of the License, or
+  * (at your option) any later version.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "version.h"
+
+#include <boost/config/helper_macros.hpp>
+
+namespace Version {
+    std::string get() {
+        std::string ret;
+#ifdef VERSION
+        ret = " (v" + std::string(BOOST_STRINGIZE(VERSION)) + ")";
+#endif
+        return ret;
+    }
+}

--- a/source/util/version.cpp
+++ b/source/util/version.cpp
@@ -18,13 +18,13 @@
 
 #include "version.h"
 
-#include <boost/config/helper_macros.hpp>
+#include <boost/preprocessor/stringize.hpp>
 
 namespace Version {
     std::string get() {
         std::string ret;
 #ifdef PTE_VERSION
-        ret = " (v" + std::string(BOOST_STRINGIZE(VERSION)) + ")";
+        ret = " (v" + std::string(BOOST_PP_STRINGIZE(PTE_VERSION)) + ")";
 #else
 #error A PTE_VERSION must be set. Make sure nothing has broken in the build process.
 #endif

--- a/source/util/version.cpp
+++ b/source/util/version.cpp
@@ -23,8 +23,10 @@
 namespace Version {
     std::string get() {
         std::string ret;
-#ifdef VERSION
+#ifdef PTE_VERSION
         ret = " (v" + std::string(BOOST_STRINGIZE(VERSION)) + ")";
+#else
+#error A PTE_VERSION must be set. Make sure nothing has broken in the build process.
 #endif
         return ret;
     }

--- a/source/util/version.h
+++ b/source/util/version.h
@@ -1,0 +1,28 @@
+/*
+  * Copyright (C) 2020 Cameron White
+  * Copyright (C) 2021 Simon Symeonidis
+  *
+  * This program is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 3 of the License, or
+  * (at your option) any later version.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef UTIL_VERSION_H
+#define UTIL_VERSION_H
+
+#include <string>
+
+namespace Version {
+    std::string get();
+};
+
+#endif


### PR DESCRIPTION
### Description of Change(s)
Add version information dialog so that problems can be reported much easier. 

![screen](https://user-images.githubusercontent.com/505688/112695398-5b022480-8e5a-11eb-9e63-e929f6568d75.png)

So I plan to tie in future work for logging by adding another tab where you can copy logs from this dialog to post on github. Feel free to reject these changes if you think they're superfluous -- opening right now to start a convo!

NB: I moved some code around, let me know if you agree with that too. 

### Fixes Issue(s)
- N/A

(lemme know what you think and if you deem this worthwhile, I'll fix up this PR)
