### PR TITLE
build: explicitly include std::optional in midiplayer.h

### DIFF
--- a/source/audio/midiplayer.h
+++ b/source/audio/midiplayer.h
@@ -14,7 +14,7 @@
   * You should have received a copy of the GNU General Public License
   * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-  
+
 #ifndef AUDIO_MIDIPLAYER_H
 #define AUDIO_MIDIPLAYER_H
 
@@ -23,6 +23,7 @@
 #include <midi/midievent.h>
 #include <QObject>
 #include <score/scorelocation.h>
+#include <optional>
 
 class MidiFile;
 class MidiOutputDevice;


### PR DESCRIPTION
### Description of Change(s)

When trying to build this project on my machine, I got a compilation
error, complaining that the 'optional' type was not recognized.  I had
to explicitly include it in order to compile successfully.

Compilation was attempted with: gcc (GCC) 11.1.0

### Fixes Issue(s)
- N/A