### PR TITLE
Make time signature visible by default

### DIFF
--- a/source/dialogs/timesignaturedialog.cpp
+++ b/source/dialogs/timesignaturedialog.cpp
@@ -50,6 +50,8 @@ TimeSignatureDialog::TimeSignatureDialog(
         pattern->setValidator(new QIntValidator(0, 64, pattern));
     }
 
+    myTimeSignature.setVisible(true);   // make the time signature visible by default
+
     ui->showTimeSignature->setChecked(myTimeSignature.isVisible());
     ui->commonTime->setChecked(myTimeSignature.getMeterType() ==
                                TimeSignature::CommonTime);


### PR DESCRIPTION
### Description of Change(s)
Make the time signature visible by default whenever the "Edit Time Signature" dialog is opened.

### Fixes Issue(s)
- #356 
