### PR TITLE
Add functional header to include std::greater

### DIFF
--- a/source/app/viewoptions.cpp
+++ b/source/app/viewoptions.cpp
@@ -18,6 +18,7 @@
 #include "viewoptions.h"
 
 #include <algorithm>
+#include <functional> /* std::greater */
 
 ViewOptions::ViewOptions() : myZoom(100)
 {


### PR DESCRIPTION
### Description of Change(s)

This would make the compiler unhappy when trying to build with the
following message:

```
  [412/525] Building CXX object source/app/CMakeFiles/pteapp.dir/viewoptions.cpp.o
  FAILED: source/app/CMakeFiles/pteapp.dir/viewoptions.cpp.o
  powertabeditor/source/app/viewoptions.cpp: In member function ‘bool ViewOptions::decreaseZoom()’:
  powertabeditor/source/app/viewoptions.cpp:40:100: error: ‘greater’ is not a member of ‘std’
     40 |     int prevZoom = *std::upper_bound(ZOOM_LEVELS.rbegin(), ZOOM_LEVELS.rend() - 1, getZoom(), std::greater<int>());
        |                                                                                                    ^~~~~~~
  powertabeditor/source/app/viewoptions.cpp:40:108: error: expected primary-expression before ‘int’
     40 |     int prevZoom = *std::upper_bound(ZOOM_LEVELS.rbegin(), ZOOM_LEVELS.rend() - 1, getZoom(), std::greater<int>());
        |
```
### Fixes Issue(s)
- N/A