### PR TITLE
Fix typos

### DIFF
--- a/source/app/command.h
+++ b/source/app/command.h
@@ -47,7 +47,7 @@ private:
     /// Returns the name of the key used for storing the customized shortcut.
     std::string getSettingsKey() const;
 
-    /// Unique identifer (used when storing a customized key sequence).
+    /// Unique identifier (used when storing a customized key sequence).
     const QString myId;
     const QKeySequence myDefaultShortcut;
 };

--- a/source/app/powertabeditor.cpp
+++ b/source/app/powertabeditor.cpp
@@ -3830,7 +3830,7 @@ canDeleteItem(ScoreItem item)
             return false;
     }
 
-    // This is unreachable, but neccessary to avoid a gcc warning.
+    // This is unreachable, but necessary to avoid a gcc warning.
     return false;
 }
 }

--- a/source/app/powertabeditor.h
+++ b/source/app/powertabeditor.h
@@ -338,7 +338,7 @@ private:
                                        const QKeySequence &shortcut,
                                        Position::SimpleProperty property,
                                        const QString &iconFileName = QString());
-    /// Helper function to reate a dynamic command.
+    /// Helper function to create a dynamic command.
     void createDynamicCommand(Command *&command,
                               const QString &menuName,
                               const QString &commandName,

--- a/source/dialogs/keyboardsettingsdialog.cpp
+++ b/source/dialogs/keyboardsettingsdialog.cpp
@@ -127,7 +127,7 @@ void KeyboardSettingsDialog::processKeyPress(QKeyEvent *e)
 {
     int key = e->key();
 
-    // Ignore a modifer key by itself (i.e. just the Ctrl key).
+    // Ignore a modifier key by itself (i.e. just the Ctrl key).
     if (key == Qt::Key_Control || key == Qt::Key_Shift ||
             key == Qt::Key_Meta || key == Qt::Key_Alt)
     {
@@ -144,7 +144,7 @@ void KeyboardSettingsDialog::processKeyPress(QKeyEvent *e)
     }
     else
     {
-        // Add in any modifers like Shift or Ctrl, but remove the keypad modifer
+        // Add in any modifiers like Shift or Ctrl, but remove the keypad modifier
         // since QKeySequence doesn't handle that well.
         key |= (e->modifiers() & ~Qt::KeypadModifier);
         

--- a/source/painters/chorddiagrampainter.cpp
+++ b/source/painters/chorddiagrampainter.cpp
@@ -197,7 +197,7 @@ ChordDiagramPainter::hoverLeaveEvent(QGraphicsSceneHoverEvent *event)
 }
 
 /// Empty graphics item to be the parent for the chord diagrams, since they
-/// aren't invidually selectable if they're part of a QGraphicsItemGroup.
+/// aren't individually selectable if they're part of a QGraphicsItemGroup.
 class EmptyGraphicsItem : public QGraphicsItem
 {
 public:

--- a/source/score/generalmidi.h
+++ b/source/score/generalmidi.h
@@ -59,7 +59,7 @@ namespace Midi
     /// Maximum volume level for a MIDI channel.
     const uint8_t MAX_MIDI_CHANNEL_VOLUME = 0x7f;
 
-    /// Miniumum level for channel effects (chorus, reverb, etc.).
+    /// Minimum level for channel effects (chorus, reverb, etc.).
     const uint8_t MIN_MIDI_CHANNEL_EFFECT_LEVEL = 0;
     /// Maximum level for channel effects (chorus, reverb, etc.).
     const uint8_t MAX_MIDI_CHANNEL_EFFECT_LEVEL = 0x7f;

--- a/xdg/powertabeditor.metainfo.xml
+++ b/xdg/powertabeditor.metainfo.xml
@@ -85,7 +85,7 @@
         <ul>
           <li>Tuning dictionary changes (#367)
           <ul>
-            <li>The tuning dictionary in the user prefs folder (`tunings.json`) now only stores custom tunings instead of the entire tuning dictionay</li>
+            <li>The tuning dictionary in the user prefs folder (`tunings.json`) now only stores custom tunings instead of the entire tuning dictionary</li>
             <li>The user tuning dictionary is now combined with the default tuning dictionary when loaded, ensuring that updates to the default tunings take effey</li>
             <li>Reordered the default tuning dictionary so that "Down 1/2 Step", "Down 1 Step" etc tunings are next to the standard tuning (#36y</li>
           </ul>


### PR DESCRIPTION
Found via `codespell -q 3 -S "*.rtf,*.ts,./source/formats/powertab_old" -L ons`

### Description of Change(s)

Misc. source comment typo fixes

### Fixes Issue(s)

n/a