### PR TITLE
Add an explicit English translation

### DIFF
--- a/source/build/osx/Info.plist.in
+++ b/source/build/osx/Info.plist.in
@@ -125,6 +125,7 @@
         <key>CFBundleLocalizations</key>
         <array>
             <string>de</string>
+            <string>en</string>
             <string>en_CA</string>
             <string>es</string>
             <string>fr</string>

--- a/translations/CMakeLists.txt
+++ b/translations/CMakeLists.txt
@@ -1,6 +1,7 @@
 # NOTE: this must be synchronized with source/build/osx/Info.plist.in for the macOS app bundle.
 set( languages
     de
+    en
     en_CA
     es
     fr

--- a/translations/powertabeditor_de.ts
+++ b/translations/powertabeditor_de.ts
@@ -54,7 +54,7 @@
     <message>
         <location filename="../source/actions/adddirection.cpp" line="24"/>
         <source>Add Musical Direction</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Add Musical Direction</translation>
     </message>
 </context>
 <context>
@@ -123,7 +123,7 @@
     <message>
         <location filename="../source/actions/addplayer.cpp" line="23"/>
         <source>Add Player</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Add Player</translation>
     </message>
 </context>
 <context>
@@ -147,7 +147,7 @@
     <message>
         <location filename="../source/actions/editrehearsalsign.cpp" line="25"/>
         <source>Add Rehearsal Sign</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Add Rehearsal Sign</translation>
     </message>
 </context>
 <context>
@@ -155,7 +155,7 @@
     <message>
         <location filename="../source/actions/addrest.cpp" line="23"/>
         <source>Add Rest</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Add Rest</translation>
     </message>
 </context>
 <context>
@@ -192,7 +192,7 @@
     <message>
         <location filename="../source/actions/edittempomarker.cpp" line="27"/>
         <source>Add Tempo Marker</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Add Tempo Marker</translation>
     </message>
 </context>
 <context>
@@ -429,7 +429,7 @@
     <message>
         <location filename="../source/dialogs/benddialog.ui" line="73"/>
         <source>Default</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Standard</translation>
     </message>
     <message>
         <location filename="../source/dialogs/benddialog.ui" line="85"/>
@@ -531,12 +531,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/bulkconverterdialog.cpp" line="172"/>
+        <location filename="../source/dialogs/bulkconverterdialog.cpp" line="170"/>
         <source>Convert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/bulkconverterdialog.cpp" line="190"/>
+        <location filename="../source/dialogs/bulkconverterdialog.cpp" line="188"/>
         <source>Directory To Convert</source>
         <translation type="unfinished"></translation>
     </message>
@@ -582,7 +582,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chorddiagramdialog.cpp" line="48"/>
+        <location filename="../source/dialogs/chorddiagramdialog.cpp" line="47"/>
         <source>Click to edit chord name.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -610,79 +610,84 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="95"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="702"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="94"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="694"/>
         <source>C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="115"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="722"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="113"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="713"/>
         <source>D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="135"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="742"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="132"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="732"/>
         <source>E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="155"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="762"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="151"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="751"/>
         <source>F</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="175"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="782"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="170"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="770"/>
         <source>G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="195"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="802"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="189"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="789"/>
         <source>A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="215"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="822"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="208"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="808"/>
         <source>B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="300"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="293"/>
         <source>Brackets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="309"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="302"/>
         <source>Formula:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="316"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="309"/>
         <source>Additions:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="323"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="316"/>
         <source>Extensions:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="330"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="323"/>
         <source>Alterations:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="337"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="330"/>
         <source>Bass Note:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="911"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="892"/>
+        <source>Custom Label</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="907"/>
         <source>Chords in Score:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1846,17 +1851,17 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/widgets/playback/playbackwidget.ui" line="103"/>
+        <location filename="../source/widgets/playback/playbackwidget.ui" line="109"/>
         <source>Adjusts the current playback speed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/widgets/playback/playbackwidget.ui" line="175"/>
+        <location filename="../source/widgets/playback/playbackwidget.ui" line="181"/>
         <source>Zoom:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/widgets/playback/playbackwidget.ui" line="220"/>
+        <location filename="../source/widgets/playback/playbackwidget.ui" line="223"/>
         <source>System: 1, Staff: 1, Position: 1, String: 1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1901,7 +1906,7 @@
     <message>
         <location filename="../source/dialogs/playerchangedialog.cpp" line="41"/>
         <source>Instrument</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Instrument</translation>
     </message>
     <message>
         <location filename="../source/dialogs/playerchangedialog.cpp" line="43"/>
@@ -1933,1014 +1938,1019 @@
 <context>
     <name>PowerTabEditor</name>
     <message>
-        <location filename="../source/app/clipboard.cpp" line="129"/>
-        <source>Cannot paste notes from a different tuning.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../source/app/powertabeditor.cpp" line="175"/>
+        <location filename="../source/app/powertabeditor.cpp" line="179"/>
         <source>Toolbox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="248"/>
+        <location filename="../source/app/powertabeditor.cpp" line="252"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="278"/>
-        <location filename="../source/app/powertabeditor.cpp" line="303"/>
+        <location filename="../source/app/powertabeditor.cpp" line="282"/>
+        <location filename="../source/app/powertabeditor.cpp" line="307"/>
         <source>Error Opening File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="279"/>
-        <location filename="../source/app/powertabeditor.cpp" line="400"/>
+        <location filename="../source/app/powertabeditor.cpp" line="283"/>
+        <location filename="../source/app/powertabeditor.cpp" line="405"/>
         <source>Unsupported file type.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="304"/>
+        <location filename="../source/app/powertabeditor.cpp" line="308"/>
         <source>Error opening file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="337"/>
+        <location filename="../source/app/powertabeditor.cpp" line="342"/>
         <source>Close Document</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="338"/>
+        <location filename="../source/app/powertabeditor.cpp" line="343"/>
         <source>The document has been modified.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="339"/>
+        <location filename="../source/app/powertabeditor.cpp" line="344"/>
         <source>Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="399"/>
-        <location filename="../source/app/powertabeditor.cpp" line="414"/>
+        <location filename="../source/app/powertabeditor.cpp" line="404"/>
+        <location filename="../source/app/powertabeditor.cpp" line="419"/>
         <source>Error Saving File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="415"/>
+        <location filename="../source/app/powertabeditor.cpp" line="420"/>
         <source>Error saving file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="446"/>
+        <location filename="../source/app/powertabeditor.cpp" line="451"/>
         <source>Save As</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="538"/>
+        <location filename="../source/app/powertabeditor.cpp" line="544"/>
         <source>Cut Notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="554"/>
+        <location filename="../source/app/powertabeditor.cpp" line="560"/>
         <source>The clipboard does not contain any notes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="559"/>
+        <location filename="../source/app/powertabeditor.cpp" line="565"/>
         <source>Paste Notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="604"/>
+        <location filename="../source/app/powertabeditor.cpp" line="618"/>
         <source>Midi Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="626"/>
+        <location filename="../source/app/powertabeditor.cpp" line="640"/>
         <source>Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="662"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2303"/>
+        <location filename="../source/app/powertabeditor.cpp" line="676"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2382"/>
         <source>Play</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="885"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2466"/>
+        <location filename="../source/app/powertabeditor.cpp" line="899"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2545"/>
         <source>Remove Position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="973"/>
+        <location filename="../source/app/powertabeditor.cpp" line="987"/>
         <source>Edit Chord Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1010"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1024"/>
         <source>Edit Text Item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1058"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1072"/>
         <source>Edit Chord Diagram</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1156"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1170"/>
         <source>Edit Note Duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1386"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1400"/>
         <source>Cannot add a multi-bar rest to a non-empty measure.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1399"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1413"/>
         <source>Edit Multi-Bar Rest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1476"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1490"/>
         <source>Edit Tempo Marker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1515"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1529"/>
         <source>Edit Alteration of Pace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1562"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1576"/>
         <source>Edit Musical Direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1600"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1614"/>
         <source>Edit Repeat Ending</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1704"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1718"/>
         <source>Edit Volume Swell</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1741"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1755"/>
         <source>Edit Tremolo Bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1841"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1855"/>
         <source>Edit Bend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1965"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1979"/>
         <source>Edit Player Change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2192"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2264"/>
         <source>Untitled</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Ohne Titel</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2205"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2277"/>
         <source>&amp;New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2210"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2282"/>
         <source>&amp;Open...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2215"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2287"/>
         <source>&amp;Close Tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2220"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2292"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2226"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2298"/>
         <source>Save As...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2232"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2304"/>
         <source>Print...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2238"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2310"/>
         <source>Print Preview...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2242"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2315"/>
+        <source>Open Backup Folder...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../source/app/powertabeditor.cpp" line="2321"/>
         <source>Bulk Converter...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2248"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2327"/>
         <source>Customize Shortcuts...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2254"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2333"/>
         <source>&amp;Preferences...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2260"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2339"/>
         <source>&amp;Quit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2265"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2344"/>
         <source>&amp;Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2268"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2347"/>
         <source>&amp;Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2272"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2351"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2276"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2355"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2281"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2360"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2285"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2364"/>
         <source>Polish Score</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2290"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2369"/>
         <source>Polish System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2297"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2376"/>
         <source>File Information...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2315"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2394"/>
         <source>Play From Start Of Measure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2322"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2401"/>
         <source>Stop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2326"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2405"/>
         <source>Rewind</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2331"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2410"/>
         <source>Metronome</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2337"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2416"/>
         <source>Count-In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2345"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2424"/>
         <source>First Section</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2351"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2430"/>
         <source>Next Section</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2357"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2436"/>
         <source>Previous Section</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2363"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2442"/>
         <source>Last Section</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2369"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2448"/>
         <source>Insert Space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2375"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2454"/>
         <source>Remove Space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2391"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2470"/>
         <source>Move to &amp;Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2397"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2476"/>
         <source>&amp;Next Position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2403"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2482"/>
         <source>&amp;Previous Position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2409"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2488"/>
         <source>Next String</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2415"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2494"/>
         <source>Previous String</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2421"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2500"/>
         <source>Move to &amp;End</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2427"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2506"/>
         <source>Next Staff</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2433"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2512"/>
         <source>Previous Staff</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2438"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2517"/>
         <source>Next Bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2444"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2523"/>
         <source>Previous Bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2460"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2539"/>
         <source>Remove Selected Item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2471"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2550"/>
         <source>Go To Barline...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2477"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2556"/>
         <source>Go To Rehearsal Sign...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2484"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2563"/>
         <source>Chord Name...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2490"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2569"/>
         <source>Text...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2498"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2577"/>
         <source>Add Chord Diagram...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2503"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2582"/>
         <source>Insert System At End</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2509"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2588"/>
         <source>Insert System Before</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2516"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2595"/>
         <source>Insert System After</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2523"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2602"/>
         <source>Remove Current System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2531"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2610"/>
         <source>Insert Staff Before</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2537"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2616"/>
         <source>Insert Staff After</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2543"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2622"/>
         <source>Remove Current Staff</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2548"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2627"/>
         <source>Increase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2555"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2634"/>
         <source>Decrease</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2564"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2707"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2643"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2786"/>
         <source>Whole</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2567"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2709"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2646"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2788"/>
         <source>Half</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2570"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2711"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2649"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2790"/>
         <source>Quarter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2573"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2713"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2652"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2792"/>
         <source>8th</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2576"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2715"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2655"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2794"/>
         <source>16th</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2579"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2717"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2658"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2796"/>
         <source>32nd</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2583"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2720"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2662"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2799"/>
         <source>64th</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2588"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2667"/>
         <source>Increase Duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2595"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2674"/>
         <source>Decrease Duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2602"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2681"/>
         <source>Dotted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2606"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2685"/>
         <source>Double Dotted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2611"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2690"/>
         <source>Add Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2615"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2694"/>
         <source>Remove Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2619"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2698"/>
         <source>Left Hand Fingering...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2628"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2707"/>
         <source>Shift String Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2634"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2713"/>
         <source>Shift String Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2639"/>
-        <location filename="../source/app/powertabeditor.cpp" line="3933"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2718"/>
+        <location filename="../source/app/powertabeditor.cpp" line="4010"/>
         <source>Tied</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2644"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2723"/>
         <source>Muted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2647"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2726"/>
         <source>Ghost Note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2651"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2730"/>
         <source>Fermata</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2655"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2734"/>
         <source>Let Ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2659"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2738"/>
         <source>Grace Note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2664"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2743"/>
         <source>Staccato</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2668"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2747"/>
         <source>Accent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2672"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2751"/>
         <source>Heavy Accent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2678"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2757"/>
         <source>8va</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2681"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2760"/>
         <source>15ma</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2684"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2763"/>
         <source>8vb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2687"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2766"/>
         <source>15mb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2691"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2770"/>
         <source>Triplet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2698"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2777"/>
         <source>Irregular Grouping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2724"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2803"/>
         <source>Add Rest</source>
         <translation type="unfinished">Add Rest</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2730"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2809"/>
         <source>Multi-Bar Rest...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2738"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2817"/>
         <source>Rehearsal Sign...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2745"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2824"/>
         <source>Tempo Marker...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2752"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2831"/>
         <source>Alteration of Pace...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2758"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2837"/>
         <source>Edit Key Signature...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2765"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2844"/>
         <source>Edit Time Signature...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2772"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2851"/>
         <source>Insert Standard Barline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2779"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2858"/>
         <source>Barline...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2785"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2864"/>
         <source>Musical Direction...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2793"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2872"/>
         <source>Repeat Ending...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2801"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2880"/>
         <source>Dynamic...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2808"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2811"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2814"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2817"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2820"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2823"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2826"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2829"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2887"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2890"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2893"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2896"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2899"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2902"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2905"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2908"/>
         <source>Dynamics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2834"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2913"/>
         <source>Volume Swell...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2841"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2920"/>
         <source>Hammer On/Pull Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2849"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2928"/>
         <source>Hammer On From Nowhere</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2854"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2933"/>
         <source>Pull Off To Nowhere</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2858"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2937"/>
         <source>Natural Harmonic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2863"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2942"/>
         <source>Artificial Harmonic...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2870"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2949"/>
         <source>Tapped Harmonic...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2879"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2958"/>
         <source>Bend...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2886"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2965"/>
         <source>Tremolo Bar...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2892"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2971"/>
         <source>Vibrato</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2897"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2976"/>
         <source>Wide Vibrato</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2902"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2981"/>
         <source>Palm Mute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2906"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2985"/>
         <source>Tremolo Picking</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2910"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2989"/>
         <source>Arpeggio Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2915"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2994"/>
         <source>Arpeggio Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2920"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2999"/>
         <source>Tap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2924"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3003"/>
         <source>Trill...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2930"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3009"/>
         <source>Pickstroke Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2935"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3014"/>
         <source>Pickstroke Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2941"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3020"/>
         <source>Slide Into From Above</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2946"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3025"/>
         <source>Slide Into From Below</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2951"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3030"/>
         <source>Shift Slide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2955"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3034"/>
         <source>Legato Slide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2961"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3040"/>
         <source>Slide Out Of Downwards</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2966"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3045"/>
         <source>Slide Out Of Upwards</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2973"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3052"/>
         <source>Add Player</source>
         <translation type="unfinished">Add Player</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2978"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3057"/>
         <source>Add Instrument</source>
         <translation type="unfinished">Add Instrument</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2982"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3061"/>
         <source>Player Change...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2989"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3068"/>
         <source>Tuning Dictionary...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2996"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3075"/>
         <source>Edit View Filters...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3013"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3092"/>
         <source>Next Tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3019"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3098"/>
         <source>Previous Tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3033"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3112"/>
         <source>Zoom In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3038"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3117"/>
         <source>Zoom Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3044"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3123"/>
         <source>Report Bug...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3050"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3129"/>
         <source>Translate This Application...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3056"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3135"/>
         <source>Application Info...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3100"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3179"/>
         <source>Mixer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3125"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3204"/>
         <source>Instruments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3228"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3307"/>
         <source>&amp;File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3239"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3318"/>
         <source>Recent Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3249"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3329"/>
         <source>&amp;Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3265"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3345"/>
         <source>Play&amp;back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3274"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3354"/>
         <source>&amp;Position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3275"/>
-        <location filename="../source/app/powertabeditor.cpp" line="3311"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3355"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3391"/>
         <source>&amp;Section</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3281"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3361"/>
         <source>&amp;Staff</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3304"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3384"/>
         <source>&amp;Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3321"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3401"/>
         <source>&amp;Line Spacing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3326"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3406"/>
         <source>&amp;Notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3360"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3440"/>
         <source>Octave</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3370"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3450"/>
         <source>Rests</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3383"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3463"/>
         <source>&amp;Music Symbols</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3397"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3477"/>
         <source>&amp;Tab Symbols</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3398"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3478"/>
         <source>&amp;Hammer Ons/Pull Offs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3412"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3492"/>
         <source>Slide Into</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3419"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3499"/>
         <source>Slide Out Of</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3439"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3519"/>
         <source>&amp;Player</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3448"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3528"/>
         <source>&amp;Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3459"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3539"/>
         <source>&amp;Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3939"/>
+        <location filename="../source/app/powertabeditor.cpp" line="4016"/>
         <source>Insert Tied Note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="4034"/>
+        <location filename="../source/app/powertabeditor.cpp" line="4111"/>
         <source>Edit Barline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="4039"/>
+        <location filename="../source/app/powertabeditor.cpp" line="4116"/>
         <source>Insert Barline</source>
         <translation type="unfinished">Insert Barline</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="4045"/>
+        <location filename="../source/app/powertabeditor.cpp" line="4122"/>
         <source>Barline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/build/main.cpp" line="201"/>
+        <location filename="../source/build/main.cpp" line="191"/>
         <source>A guitar tablature editor.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/build/main.cpp" line="207"/>
+        <location filename="../source/build/main.cpp" line="197"/>
         <source>The files to be opened</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../source/app/clipboard.cpp" line="130"/>
+        <source>Cannot paste notes from a different number of strings.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2978,7 +2988,7 @@
     </message>
     <message>
         <location filename="../source/dialogs/preferencesdialog.ui" line="86"/>
-        <source>Play Notes While Editing</source>
+        <source>Play Notes While Editing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2995,7 +3005,7 @@
     <message>
         <location filename="../source/dialogs/preferencesdialog.ui" line="122"/>
         <location filename="../source/dialogs/preferencesdialog.ui" line="193"/>
-        <location filename="../source/dialogs/preferencesdialog.ui" line="322"/>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="355"/>
         <source>Preset:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3060,27 +3070,42 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/preferencesdialog.ui" line="297"/>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="296"/>
+        <source>Backup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="304"/>
+        <source>Enable Auto Backup:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="314"/>
+        <source>Backup Interval (seconds):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="330"/>
         <source>Default Instrument</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/preferencesdialog.ui" line="312"/>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="345"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/preferencesdialog.ui" line="332"/>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="365"/>
         <source>Tuning:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/preferencesdialog.ui" line="339"/>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="372"/>
         <source>Tuning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/preferencesdialog.cpp" line="146"/>
+        <location filename="../source/dialogs/preferencesdialog.cpp" line="148"/>
         <source>Click to adjust tuning.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3181,7 +3206,7 @@
     <message>
         <location filename="../source/actions/removeinstrument.cpp" line="23"/>
         <source>Remove Instrument</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Instrument entfernen</translation>
     </message>
 </context>
 <context>
@@ -3221,7 +3246,7 @@
     <message>
         <location filename="../source/actions/removeplayer.cpp" line="23"/>
         <source>Remove Player</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Spieler entfernen</translation>
     </message>
 </context>
 <context>
@@ -3240,7 +3265,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1355"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1369"/>
         <source>Remove Multi-Bar Rest</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3353,67 +3378,67 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="155"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="150"/>
         <source>Double-click to change clef type.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="197"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="192"/>
         <source>Double-click to edit the number of strings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="304"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="298"/>
         <source>Double-click to edit rehearsal sign.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="507"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="500"/>
         <source>Double-click to edit repeat endings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="638"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="634"/>
         <source>Double-click to edit tempo marker.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="745"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="741"/>
         <source>Double-click to edit chord text.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="771"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="767"/>
         <source>Double-click to edit text.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="941"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="937"/>
         <source>Double-click to edit the active players.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="1394"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="1389"/>
         <source>Double-click to edit volume swell.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="1414"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="1409"/>
         <source>Double-click to edit tremolo bar.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="1589"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="1583"/>
         <source>Double-click to edit dynamic.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="1932"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="1926"/>
         <source>Double-click to edit multi-bar rest.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="2185"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="2178"/>
         <source>Double-click to edit bend.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/powertabeditor_en.ts
+++ b/translations/powertabeditor_en.ts
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="en_CA">
+<TS version="2.1" language="en_US">
 <context>
     <name>AddAlternateEnding</name>
     <message>
         <location filename="../source/actions/addalternateending.cpp" line="24"/>
         <source>Add Repeat Ending</source>
-        <translation>Add Repeat Ending</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -14,7 +14,7 @@
     <message>
         <location filename="../source/actions/addspecialnoteproperty.h" line="93"/>
         <source>Add Artificial Harmonic</source>
-        <translation>Add Artificial Harmonic</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -22,7 +22,7 @@
     <message>
         <location filename="../source/actions/addbarline.cpp" line="23"/>
         <source>Insert Barline</source>
-        <translation>Insert Barline</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -30,7 +30,7 @@
     <message>
         <location filename="../source/actions/addspecialnoteproperty.h" line="106"/>
         <source>Add Bend</source>
-        <translation>Add Bend</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -46,7 +46,7 @@
     <message>
         <location filename="../source/actions/addchordtext.cpp" line="24"/>
         <source>Add Chord Text</source>
-        <translation>Add Chord Text</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -54,7 +54,7 @@
     <message>
         <location filename="../source/actions/adddirection.cpp" line="24"/>
         <source>Add Musical Direction</source>
-        <translation>Add Musical Direction</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -62,7 +62,7 @@
     <message>
         <location filename="../source/actions/adddynamic.cpp" line="23"/>
         <source>Add Dynamic</source>
-        <translation>Add Dynamic</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -70,7 +70,7 @@
     <message>
         <location filename="../source/actions/addinstrument.cpp" line="23"/>
         <source>Add Instrument</source>
-        <translation>Add Instrument</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -78,12 +78,12 @@
     <message>
         <location filename="../source/actions/addirregulargrouping.cpp" line="27"/>
         <source>Add Triplet</source>
-        <translation>Add Triplet</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../source/actions/addirregulargrouping.cpp" line="29"/>
         <source>Add Irregular Grouping</source>
-        <translation>Add Irregular Grouping</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -91,7 +91,7 @@
     <message>
         <location filename="../source/actions/addspecialnoteproperty.h" line="120"/>
         <source>Add Left Hand Fingering</source>
-        <translation>Add Left Hand Fingering</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -99,7 +99,7 @@
     <message>
         <location filename="../source/actions/addmultibarrest.cpp" line="23"/>
         <source>Add Multi-Bar Rest</source>
-        <translation>Add Multi-Bar Rest</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -107,7 +107,7 @@
     <message>
         <location filename="../source/actions/addnote.cpp" line="24"/>
         <source>Add Note</source>
-        <translation>Add Note</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -115,7 +115,7 @@
     <message>
         <location filename="../source/actions/addnoteproperty.cpp" line="23"/>
         <source>Set %1</source>
-        <translation>Set %1</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -123,7 +123,7 @@
     <message>
         <location filename="../source/actions/addplayer.cpp" line="23"/>
         <source>Add Player</source>
-        <translation>Add Player</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -131,7 +131,7 @@
     <message>
         <location filename="../source/actions/editplayerchange.cpp" line="25"/>
         <source>Add Player Change</source>
-        <translation>Add Player Change</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -139,7 +139,7 @@
     <message>
         <location filename="../source/actions/addpositionproperty.cpp" line="23"/>
         <source>Set %1</source>
-        <translation>Set %1</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -147,7 +147,7 @@
     <message>
         <location filename="../source/actions/editrehearsalsign.cpp" line="25"/>
         <source>Add Rehearsal Sign</source>
-        <translation>Add Rehearsal Sign</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -155,7 +155,7 @@
     <message>
         <location filename="../source/actions/addrest.cpp" line="23"/>
         <source>Add Rest</source>
-        <translation>Add Rest</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -163,7 +163,7 @@
     <message>
         <location filename="../source/actions/addstaff.cpp" line="23"/>
         <source>Add Staff</source>
-        <translation>Add Staff</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -171,7 +171,7 @@
     <message>
         <location filename="../source/actions/addsystem.cpp" line="23"/>
         <source>Add System</source>
-        <translation>Add System</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -179,7 +179,7 @@
     <message>
         <location filename="../source/actions/addspecialnoteproperty.h" line="65"/>
         <source>Add Tapped Harmonic</source>
-        <translation>Add Tapped Harmonic</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -187,12 +187,12 @@
     <message>
         <location filename="../source/actions/edittempomarker.cpp" line="26"/>
         <source>Add Alteration of Pace</source>
-        <translation>Add Alteration of Pace</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../source/actions/edittempomarker.cpp" line="27"/>
         <source>Add Tempo Marker</source>
-        <translation>Add Tempo Marker</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -200,7 +200,7 @@
     <message>
         <location filename="../source/actions/edittextitem.cpp" line="24"/>
         <source>Add Text</source>
-        <translation>Add Text</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -208,7 +208,7 @@
     <message>
         <location filename="../source/actions/tremolobar.cpp" line="22"/>
         <source>Add Tremolo Bar</source>
-        <translation>Add Tremolo Bar</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -216,7 +216,7 @@
     <message>
         <location filename="../source/actions/addspecialnoteproperty.h" line="78"/>
         <source>Add Trill</source>
-        <translation>Add Trill</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -224,7 +224,7 @@
     <message>
         <location filename="../source/actions/volumeswell.cpp" line="22"/>
         <source>Add Volume Swell</source>
-        <translation>Add Volume Swell</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -515,6 +515,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../source/dialogs/bulkconverterdialog.ui" line="56"/>
+        <location filename="../source/dialogs/bulkconverterdialog.ui" line="84"/>
+        <source>...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../source/dialogs/bulkconverterdialog.ui" line="65"/>
         <source>Destination Directory:</source>
         <translation type="unfinished"></translation>
@@ -522,12 +528,6 @@
     <message>
         <location filename="../source/dialogs/bulkconverterdialog.ui" line="93"/>
         <source>Convert To:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../source/dialogs/bulkconverterdialog.ui" line="56"/>
-        <location filename="../source/dialogs/bulkconverterdialog.ui" line="84"/>
-        <source>...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1938,6 +1938,11 @@
 <context>
     <name>PowerTabEditor</name>
     <message>
+        <location filename="../source/app/clipboard.cpp" line="130"/>
+        <source>Cannot paste notes from a different number of strings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../source/app/powertabeditor.cpp" line="179"/>
         <source>Toolbox</source>
         <translation type="unfinished"></translation>
@@ -2553,7 +2558,7 @@
     <message>
         <location filename="../source/app/powertabeditor.cpp" line="2803"/>
         <source>Add Rest</source>
-        <translation type="unfinished">Add Rest</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../source/app/powertabeditor.cpp" line="2809"/>
@@ -2750,12 +2755,12 @@
     <message>
         <location filename="../source/app/powertabeditor.cpp" line="3052"/>
         <source>Add Player</source>
-        <translation type="unfinished">Add Player</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../source/app/powertabeditor.cpp" line="3057"/>
         <source>Add Instrument</source>
-        <translation type="unfinished">Add Instrument</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../source/app/powertabeditor.cpp" line="3061"/>
@@ -2931,7 +2936,7 @@
     <message>
         <location filename="../source/app/powertabeditor.cpp" line="4116"/>
         <source>Insert Barline</source>
-        <translation type="unfinished">Insert Barline</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../source/app/powertabeditor.cpp" line="4122"/>
@@ -2946,11 +2951,6 @@
     <message>
         <location filename="../source/build/main.cpp" line="197"/>
         <source>The files to be opened</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../source/app/clipboard.cpp" line="130"/>
-        <source>Cannot paste notes from a different number of strings.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3363,6 +3363,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../source/painters/chorddiagrampainter.cpp" line="242"/>
+        <source>Double-click to edit chord diagram.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../source/painters/directions.cpp" line="54"/>
         <source>Double-click to edit musical direction.</source>
         <translation type="unfinished"></translation>
@@ -3447,11 +3452,6 @@
         <source>Click to edit time signature.</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="../source/painters/chorddiagrampainter.cpp" line="242"/>
-        <source>Double-click to edit chord diagram.</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>ScorePage</name>
@@ -3463,7 +3463,7 @@
     <message>
         <location filename="../source/widgets/toolbox/scorepage.cpp" line="36"/>
         <source>Add Instrument</source>
-        <translation type="unfinished">Add Instrument</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../source/widgets/toolbox/scorepage.cpp" line="40"/>
@@ -3528,17 +3528,17 @@
     <message>
         <location filename="../source/widgets/toolbox/scorepage.cpp" line="117"/>
         <source>Add Rehearsal Sign</source>
-        <translation type="unfinished">Add Rehearsal Sign</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../source/widgets/toolbox/scorepage.cpp" line="121"/>
         <source>Add Musical Direction</source>
-        <translation type="unfinished">Add Musical Direction</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../source/widgets/toolbox/scorepage.cpp" line="125"/>
         <source>Add Tempo Marker</source>
-        <translation type="unfinished">Add Tempo Marker</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../source/widgets/toolbox/scorepage.cpp" line="129"/>

--- a/translations/powertabeditor_es.ts
+++ b/translations/powertabeditor_es.ts
@@ -547,12 +547,12 @@
         <translation type="vanished">Directorio de origen</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/bulkconverterdialog.cpp" line="172"/>
+        <location filename="../source/dialogs/bulkconverterdialog.cpp" line="170"/>
         <source>Convert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/bulkconverterdialog.cpp" line="190"/>
+        <location filename="../source/dialogs/bulkconverterdialog.cpp" line="188"/>
         <source>Directory To Convert</source>
         <translation>Directorio que convertir</translation>
     </message>
@@ -598,7 +598,7 @@
         <translation>Diagrama:</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chorddiagramdialog.cpp" line="48"/>
+        <location filename="../source/dialogs/chorddiagramdialog.cpp" line="47"/>
         <source>Click to edit chord name.</source>
         <translation>Pulse para editar el nombre del acorde.</translation>
     </message>
@@ -626,79 +626,84 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="95"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="702"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="94"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="694"/>
         <source>C</source>
         <translation>Do</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="115"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="722"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="113"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="713"/>
         <source>D</source>
         <translation>Re</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="135"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="742"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="132"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="732"/>
         <source>E</source>
         <translation>Mi</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="155"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="762"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="151"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="751"/>
         <source>F</source>
         <translation>Fa</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="175"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="782"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="170"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="770"/>
         <source>G</source>
         <translation>Sol</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="195"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="802"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="189"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="789"/>
         <source>A</source>
         <translation>La</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="215"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="822"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="208"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="808"/>
         <source>B</source>
         <translation>Si</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="300"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="293"/>
         <source>Brackets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="309"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="302"/>
         <source>Formula:</source>
         <translation>Fórmula:</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="316"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="309"/>
         <source>Additions:</source>
         <translation>Adiciones:</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="323"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="316"/>
         <source>Extensions:</source>
         <translation>Extensiones:</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="330"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="323"/>
         <source>Alterations:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="337"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="330"/>
         <source>Bass Note:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="911"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="892"/>
+        <source>Custom Label</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="907"/>
         <source>Chords in Score:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1863,12 +1868,12 @@
         <translation>Velocidad:</translation>
     </message>
     <message>
-        <location filename="../source/widgets/playback/playbackwidget.ui" line="103"/>
+        <location filename="../source/widgets/playback/playbackwidget.ui" line="109"/>
         <source>Adjusts the current playback speed.</source>
         <translation>Ajusta la velocidad de reproducción actual.</translation>
     </message>
     <message>
-        <location filename="../source/widgets/playback/playbackwidget.ui" line="175"/>
+        <location filename="../source/widgets/playback/playbackwidget.ui" line="181"/>
         <source>Zoom:</source>
         <translation>Escala:</translation>
     </message>
@@ -1925,7 +1930,7 @@
         <translation type="vanished">300&#xa0;%</translation>
     </message>
     <message>
-        <location filename="../source/widgets/playback/playbackwidget.ui" line="220"/>
+        <location filename="../source/widgets/playback/playbackwidget.ui" line="223"/>
         <source>System: 1, Staff: 1, Position: 1, String: 1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2002,872 +2007,876 @@
 <context>
     <name>PowerTabEditor</name>
     <message>
-        <location filename="../source/app/clipboard.cpp" line="129"/>
         <source>Cannot paste notes from a different tuning.</source>
-        <translation>No es posible pegar notas de una afinación distinta.</translation>
+        <translation type="vanished">No es posible pegar notas de una afinación distinta.</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="175"/>
+        <location filename="../source/app/powertabeditor.cpp" line="179"/>
         <source>Toolbox</source>
         <translation>Cuadro de herramientas</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="248"/>
+        <location filename="../source/app/powertabeditor.cpp" line="252"/>
         <source>Open</source>
         <translation>Abrir</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="278"/>
-        <location filename="../source/app/powertabeditor.cpp" line="303"/>
+        <location filename="../source/app/powertabeditor.cpp" line="282"/>
+        <location filename="../source/app/powertabeditor.cpp" line="307"/>
         <source>Error Opening File</source>
         <translation>Error al abrir el archivo</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="279"/>
-        <location filename="../source/app/powertabeditor.cpp" line="400"/>
+        <location filename="../source/app/powertabeditor.cpp" line="283"/>
+        <location filename="../source/app/powertabeditor.cpp" line="405"/>
         <source>Unsupported file type.</source>
         <translation>No se admite el tipo de archivo.</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="304"/>
+        <location filename="../source/app/powertabeditor.cpp" line="308"/>
         <source>Error opening file: %1</source>
         <translation>Error al abrir el archivo: %1</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="337"/>
+        <location filename="../source/app/powertabeditor.cpp" line="342"/>
         <source>Close Document</source>
         <translation>Cerrar documento</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="338"/>
+        <location filename="../source/app/powertabeditor.cpp" line="343"/>
         <source>The document has been modified.</source>
         <translation>Se ha modificado el documento.</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="339"/>
+        <location filename="../source/app/powertabeditor.cpp" line="344"/>
         <source>Do you want to save your changes?</source>
         <translation>¿Quiere guardar los cambios?</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="399"/>
-        <location filename="../source/app/powertabeditor.cpp" line="414"/>
+        <location filename="../source/app/powertabeditor.cpp" line="404"/>
+        <location filename="../source/app/powertabeditor.cpp" line="419"/>
         <source>Error Saving File</source>
         <translation>Error al guardar el archivo</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="415"/>
+        <location filename="../source/app/powertabeditor.cpp" line="420"/>
         <source>Error saving file: %1</source>
         <translation>Error al guardar el archivo: %1</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="446"/>
+        <location filename="../source/app/powertabeditor.cpp" line="451"/>
         <source>Save As</source>
         <translation>Guardar como</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="538"/>
+        <location filename="../source/app/powertabeditor.cpp" line="544"/>
         <source>Cut Notes</source>
         <translation>Cortar notas</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="554"/>
+        <location filename="../source/app/powertabeditor.cpp" line="560"/>
         <source>The clipboard does not contain any notes.</source>
         <translation>El portapapeles no contiene ninguna nota.</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="559"/>
+        <location filename="../source/app/powertabeditor.cpp" line="565"/>
         <source>Paste Notes</source>
         <translation>Pegar notas</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="604"/>
+        <location filename="../source/app/powertabeditor.cpp" line="618"/>
         <source>Midi Error</source>
         <translation>Error de MIDI</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="626"/>
+        <location filename="../source/app/powertabeditor.cpp" line="640"/>
         <source>Pause</source>
         <translation>Pausar</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="662"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2303"/>
+        <location filename="../source/app/powertabeditor.cpp" line="676"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2382"/>
         <source>Play</source>
         <translation>Reproducir</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="885"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2466"/>
+        <location filename="../source/app/powertabeditor.cpp" line="899"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2545"/>
         <source>Remove Position</source>
         <translation>Quitar posición</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="973"/>
+        <location filename="../source/app/powertabeditor.cpp" line="987"/>
         <source>Edit Chord Text</source>
         <translation>Editar texto de acorde</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1010"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1024"/>
         <source>Edit Text Item</source>
         <translation>Editar elemento de texto</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1058"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1072"/>
         <source>Edit Chord Diagram</source>
         <translation>Editar diagrama de acorde</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1156"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1170"/>
         <source>Edit Note Duration</source>
         <translation>Editar duración de nota</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1386"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1400"/>
         <source>Cannot add a multi-bar rest to a non-empty measure.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1399"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1413"/>
         <source>Edit Multi-Bar Rest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1476"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1490"/>
         <source>Edit Tempo Marker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1515"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1529"/>
         <source>Edit Alteration of Pace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1562"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1576"/>
         <source>Edit Musical Direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1600"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1614"/>
         <source>Edit Repeat Ending</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1704"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1718"/>
         <source>Edit Volume Swell</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1741"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1755"/>
         <source>Edit Tremolo Bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1841"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1855"/>
         <source>Edit Bend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1965"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1979"/>
         <source>Edit Player Change</source>
         <translation>Editar cambio de instrumentista</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2192"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2264"/>
         <source>Untitled</source>
         <translation>Sin título</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2205"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2277"/>
         <source>&amp;New</source>
         <translation>&amp;Nuevo</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2210"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2282"/>
         <source>&amp;Open...</source>
         <translation>&amp;Abrir…</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2215"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2287"/>
         <source>&amp;Close Tab</source>
         <translation>&amp;Cerrar pestaña</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2220"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2292"/>
         <source>Save</source>
         <translation>Guardar</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2226"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2298"/>
         <source>Save As...</source>
         <translation>Guardar como…</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2232"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2304"/>
         <source>Print...</source>
         <translation>Imprimir…</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2238"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2310"/>
         <source>Print Preview...</source>
         <translation>Previsualizar impresión…</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2242"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2315"/>
+        <source>Open Backup Folder...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../source/app/powertabeditor.cpp" line="2321"/>
         <source>Bulk Converter...</source>
         <translation>Conversor en masa…</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2248"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2327"/>
         <source>Customize Shortcuts...</source>
         <translation>Personalizar atajos…</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2254"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2333"/>
         <source>&amp;Preferences...</source>
         <translation>&amp;Preferencias…</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2260"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2339"/>
         <source>&amp;Quit</source>
         <translation>&amp;Salir</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2265"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2344"/>
         <source>&amp;Undo</source>
         <translation>&amp;Deshacer</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2268"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2347"/>
         <source>&amp;Redo</source>
         <translation>&amp;Rehacer</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2272"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2351"/>
         <source>Cut</source>
         <translation>Cortar</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2276"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2355"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2281"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2360"/>
         <source>Paste</source>
         <translation>Pegar</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2285"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2364"/>
         <source>Polish Score</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2290"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2369"/>
         <source>Polish System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2297"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2376"/>
         <source>File Information...</source>
         <translation>Información del archivo…</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2315"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2394"/>
         <source>Play From Start Of Measure</source>
         <translation>Reproducir desde inicio de compás</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2322"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2401"/>
         <source>Stop</source>
         <translation>Detener</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2326"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2405"/>
         <source>Rewind</source>
         <translation>Rebobinar</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2331"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2410"/>
         <source>Metronome</source>
         <translation>Metrónomo</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2337"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2416"/>
         <source>Count-In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2345"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2424"/>
         <source>First Section</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2351"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2430"/>
         <source>Next Section</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2357"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2436"/>
         <source>Previous Section</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2363"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2442"/>
         <source>Last Section</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2369"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2448"/>
         <source>Insert Space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2375"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2454"/>
         <source>Remove Space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2391"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2470"/>
         <source>Move to &amp;Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2397"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2476"/>
         <source>&amp;Next Position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2403"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2482"/>
         <source>&amp;Previous Position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2409"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2488"/>
         <source>Next String</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2415"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2494"/>
         <source>Previous String</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2421"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2500"/>
         <source>Move to &amp;End</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2427"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2506"/>
         <source>Next Staff</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2433"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2512"/>
         <source>Previous Staff</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2438"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2517"/>
         <source>Next Bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2444"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2523"/>
         <source>Previous Bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2460"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2539"/>
         <source>Remove Selected Item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2471"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2550"/>
         <source>Go To Barline...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2477"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2556"/>
         <source>Go To Rehearsal Sign...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2484"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2563"/>
         <source>Chord Name...</source>
         <translation>Nombre del acorde…</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2490"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2569"/>
         <source>Text...</source>
         <translation>Texto…</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2498"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2577"/>
         <source>Add Chord Diagram...</source>
         <translation>Añadir diagrama de acorde…</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2503"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2582"/>
         <source>Insert System At End</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2509"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2588"/>
         <source>Insert System Before</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2516"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2595"/>
         <source>Insert System After</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2523"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2602"/>
         <source>Remove Current System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2531"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2610"/>
         <source>Insert Staff Before</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2537"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2616"/>
         <source>Insert Staff After</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2543"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2622"/>
         <source>Remove Current Staff</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2548"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2627"/>
         <source>Increase</source>
         <translation>Aumentar</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2555"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2634"/>
         <source>Decrease</source>
         <translation>Disminuir</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2564"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2707"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2643"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2786"/>
         <source>Whole</source>
         <translation>Redonda</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2567"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2709"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2646"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2788"/>
         <source>Half</source>
         <translation>Blanca</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2570"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2711"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2649"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2790"/>
         <source>Quarter</source>
         <translation>Negra</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2573"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2713"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2652"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2792"/>
         <source>8th</source>
         <translation>Corchea</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2576"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2715"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2655"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2794"/>
         <source>16th</source>
         <translation>Semicorchea</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2579"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2717"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2658"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2796"/>
         <source>32nd</source>
         <translation>Fusa</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2583"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2720"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2662"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2799"/>
         <source>64th</source>
         <translation>Semifusa</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2588"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2667"/>
         <source>Increase Duration</source>
         <translation>Aumentar duración</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2595"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2674"/>
         <source>Decrease Duration</source>
         <translation>Disminuir duración</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2602"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2681"/>
         <source>Dotted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2606"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2685"/>
         <source>Double Dotted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2611"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2690"/>
         <source>Add Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2615"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2694"/>
         <source>Remove Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2619"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2698"/>
         <source>Left Hand Fingering...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2628"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2707"/>
         <source>Shift String Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2634"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2713"/>
         <source>Shift String Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2639"/>
-        <location filename="../source/app/powertabeditor.cpp" line="3933"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2718"/>
+        <location filename="../source/app/powertabeditor.cpp" line="4010"/>
         <source>Tied</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2644"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2723"/>
         <source>Muted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2647"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2726"/>
         <source>Ghost Note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2651"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2730"/>
         <source>Fermata</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2655"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2734"/>
         <source>Let Ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2659"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2738"/>
         <source>Grace Note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2664"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2743"/>
         <source>Staccato</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2668"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2747"/>
         <source>Accent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2672"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2751"/>
         <source>Heavy Accent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2678"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2757"/>
         <source>8va</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2681"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2760"/>
         <source>15ma</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2684"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2763"/>
         <source>8vb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2687"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2766"/>
         <source>15mb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2691"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2770"/>
         <source>Triplet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2698"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2777"/>
         <source>Irregular Grouping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2724"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2803"/>
         <source>Add Rest</source>
         <translation>Añadir silencio</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2730"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2809"/>
         <source>Multi-Bar Rest...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2738"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2817"/>
         <source>Rehearsal Sign...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2745"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2824"/>
         <source>Tempo Marker...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2752"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2831"/>
         <source>Alteration of Pace...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2758"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2837"/>
         <source>Edit Key Signature...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2765"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2844"/>
         <source>Edit Time Signature...</source>
         <translation>Editar cifra de compás…</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2772"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2851"/>
         <source>Insert Standard Barline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2779"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2858"/>
         <source>Barline...</source>
         <translation>Barra de compás…</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2785"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2864"/>
         <source>Musical Direction...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2793"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2872"/>
         <source>Repeat Ending...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2801"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2880"/>
         <source>Dynamic...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2808"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2811"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2814"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2817"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2820"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2823"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2826"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2829"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2887"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2890"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2893"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2896"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2899"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2902"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2905"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2908"/>
         <source>Dynamics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2834"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2913"/>
         <source>Volume Swell...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2841"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2920"/>
         <source>Hammer On/Pull Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2849"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2928"/>
         <source>Hammer On From Nowhere</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2854"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2933"/>
         <source>Pull Off To Nowhere</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2858"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2937"/>
         <source>Natural Harmonic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2863"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2942"/>
         <source>Artificial Harmonic...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2870"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2949"/>
         <source>Tapped Harmonic...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2879"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2958"/>
         <source>Bend...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2886"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2965"/>
         <source>Tremolo Bar...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2892"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2971"/>
         <source>Vibrato</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2897"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2976"/>
         <source>Wide Vibrato</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2902"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2981"/>
         <source>Palm Mute</source>
         <translation>Silenciamiento de palma</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2906"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2985"/>
         <source>Tremolo Picking</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2910"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2989"/>
         <source>Arpeggio Up</source>
         <translation>Arpegio hacia arriba</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2915"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2994"/>
         <source>Arpeggio Down</source>
         <translation>Arpegio hacia abajo</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2920"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2999"/>
         <source>Tap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2924"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3003"/>
         <source>Trill...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2930"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3009"/>
         <source>Pickstroke Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2935"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3014"/>
         <source>Pickstroke Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2941"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3020"/>
         <source>Slide Into From Above</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2946"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3025"/>
         <source>Slide Into From Below</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2951"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3030"/>
         <source>Shift Slide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2955"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3034"/>
         <source>Legato Slide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2961"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3040"/>
         <source>Slide Out Of Downwards</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2966"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3045"/>
         <source>Slide Out Of Upwards</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2973"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3052"/>
         <source>Add Player</source>
         <translation>Añadir instrumentista</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2978"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3057"/>
         <source>Add Instrument</source>
         <translation>Añadir instrumento</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2982"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3061"/>
         <source>Player Change...</source>
         <translation>Cambio de instrumentista…</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2989"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3068"/>
         <source>Tuning Dictionary...</source>
         <translation>Diccionario de afinaciones…</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2996"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3075"/>
         <source>Edit View Filters...</source>
         <translation>Editar filtros de vista…</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3013"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3092"/>
         <source>Next Tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3019"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3098"/>
         <source>Previous Tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3033"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3112"/>
         <source>Zoom In</source>
         <translation>Acercar</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3038"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3117"/>
         <source>Zoom Out</source>
         <translation>Alejar</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3044"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3123"/>
         <source>Report Bug...</source>
         <translation>Informar de un defecto…</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3050"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3129"/>
         <source>Translate This Application...</source>
         <translation>Traducir esta aplicación…</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3056"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3135"/>
         <source>Application Info...</source>
         <translation>Información sobre la aplicación…</translation>
     </message>
@@ -2876,145 +2885,150 @@
         <translation type="vanished">Información sobre la aplicación</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3100"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3179"/>
         <source>Mixer</source>
         <translation>Mezclador</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3125"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3204"/>
         <source>Instruments</source>
         <translation>Instrumentos</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3228"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3307"/>
         <source>&amp;File</source>
         <translation>&amp;Archivo</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3239"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3318"/>
         <source>Recent Files</source>
         <translation>Archivos recientes</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3249"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3329"/>
         <source>&amp;Edit</source>
         <translation>&amp;Editar</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3265"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3345"/>
         <source>Play&amp;back</source>
         <translation>&amp;Reproducción</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3274"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3354"/>
         <source>&amp;Position</source>
         <translation>&amp;Posición</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3275"/>
-        <location filename="../source/app/powertabeditor.cpp" line="3311"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3355"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3391"/>
         <source>&amp;Section</source>
         <translation>&amp;Sección</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3281"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3361"/>
         <source>&amp;Staff</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3304"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3384"/>
         <source>&amp;Text</source>
         <translation>&amp;Texto</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3321"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3401"/>
         <source>&amp;Line Spacing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3326"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3406"/>
         <source>&amp;Notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3360"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3440"/>
         <source>Octave</source>
         <translation>Octava</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3370"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3450"/>
         <source>Rests</source>
         <translation>Silencios</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3383"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3463"/>
         <source>&amp;Music Symbols</source>
         <translation>Símbolos &amp;musicales</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3397"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3477"/>
         <source>&amp;Tab Symbols</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3398"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3478"/>
         <source>&amp;Hammer Ons/Pull Offs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3412"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3492"/>
         <source>Slide Into</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3419"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3499"/>
         <source>Slide Out Of</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3439"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3519"/>
         <source>&amp;Player</source>
         <translation>&amp;Instrumentista</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3448"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3528"/>
         <source>&amp;Window</source>
         <translation>&amp;Ventana</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3459"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3539"/>
         <source>&amp;Help</source>
         <translation>Ay&amp;uda</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3939"/>
+        <location filename="../source/app/powertabeditor.cpp" line="4016"/>
         <source>Insert Tied Note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="4034"/>
+        <location filename="../source/app/powertabeditor.cpp" line="4111"/>
         <source>Edit Barline</source>
         <translation>Editar barra de compás</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="4039"/>
+        <location filename="../source/app/powertabeditor.cpp" line="4116"/>
         <source>Insert Barline</source>
         <translation>Insertar barra de compás</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="4045"/>
+        <location filename="../source/app/powertabeditor.cpp" line="4122"/>
         <source>Barline</source>
         <translation>Barra de compás</translation>
     </message>
     <message>
-        <location filename="../source/build/main.cpp" line="201"/>
+        <location filename="../source/build/main.cpp" line="191"/>
         <source>A guitar tablature editor.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/build/main.cpp" line="207"/>
+        <location filename="../source/build/main.cpp" line="197"/>
         <source>The files to be opened</source>
         <translation>Los archivos que se abrirán</translation>
+    </message>
+    <message>
+        <location filename="../source/app/clipboard.cpp" line="130"/>
+        <source>Cannot paste notes from a different number of strings.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3050,9 +3064,13 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/preferencesdialog.ui" line="86"/>
         <source>Play Notes While Editing</source>
-        <translation>Reproducir notas al editar</translation>
+        <translation type="vanished">Reproducir notas al editar</translation>
+    </message>
+    <message>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="86"/>
+        <source>Play Notes While Editing:</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../source/dialogs/preferencesdialog.ui" line="101"/>
@@ -3068,7 +3086,7 @@
     <message>
         <location filename="../source/dialogs/preferencesdialog.ui" line="122"/>
         <location filename="../source/dialogs/preferencesdialog.ui" line="193"/>
-        <location filename="../source/dialogs/preferencesdialog.ui" line="322"/>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="355"/>
         <source>Preset:</source>
         <translation>Preajuste:</translation>
     </message>
@@ -3133,27 +3151,42 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/preferencesdialog.ui" line="297"/>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="296"/>
+        <source>Backup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="304"/>
+        <source>Enable Auto Backup:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="314"/>
+        <source>Backup Interval (seconds):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="330"/>
         <source>Default Instrument</source>
         <translation>Instrumento predeterminado</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/preferencesdialog.ui" line="312"/>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="345"/>
         <source>Name:</source>
         <translation>Nombre:</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/preferencesdialog.ui" line="332"/>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="365"/>
         <source>Tuning:</source>
         <translation>Afinación:</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/preferencesdialog.ui" line="339"/>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="372"/>
         <source>Tuning</source>
         <translation>Afinación</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/preferencesdialog.cpp" line="146"/>
+        <location filename="../source/dialogs/preferencesdialog.cpp" line="148"/>
         <source>Click to adjust tuning.</source>
         <translation>Pulse para ajustar la afinación.</translation>
     </message>
@@ -3313,7 +3346,7 @@
         <translation>Quitar posición</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1355"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1369"/>
         <source>Remove Multi-Bar Rest</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3426,67 +3459,67 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="155"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="150"/>
         <source>Double-click to change clef type.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="197"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="192"/>
         <source>Double-click to edit the number of strings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="304"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="298"/>
         <source>Double-click to edit rehearsal sign.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="507"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="500"/>
         <source>Double-click to edit repeat endings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="638"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="634"/>
         <source>Double-click to edit tempo marker.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="745"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="741"/>
         <source>Double-click to edit chord text.</source>
         <translation>Pulse dos veces para editar el texto del acorde.</translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="771"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="767"/>
         <source>Double-click to edit text.</source>
         <translation>Pulse dos veces para editar el texto.</translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="941"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="937"/>
         <source>Double-click to edit the active players.</source>
         <translation>Pulse dos veces para editar los instrumentistas activos.</translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="1394"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="1389"/>
         <source>Double-click to edit volume swell.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="1414"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="1409"/>
         <source>Double-click to edit tremolo bar.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="1589"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="1583"/>
         <source>Double-click to edit dynamic.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="1932"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="1926"/>
         <source>Double-click to edit multi-bar rest.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="2185"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="2178"/>
         <source>Double-click to edit bend.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/powertabeditor_fr.ts
+++ b/translations/powertabeditor_fr.ts
@@ -547,12 +547,12 @@
         <translation type="vanished">Dossier source</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/bulkconverterdialog.cpp" line="172"/>
+        <location filename="../source/dialogs/bulkconverterdialog.cpp" line="170"/>
         <source>Convert</source>
         <translation>Convertir</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/bulkconverterdialog.cpp" line="190"/>
+        <location filename="../source/dialogs/bulkconverterdialog.cpp" line="188"/>
         <source>Directory To Convert</source>
         <translation>Dossier à convertir</translation>
     </message>
@@ -598,7 +598,7 @@
         <translation>Diagramme :</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chorddiagramdialog.cpp" line="48"/>
+        <location filename="../source/dialogs/chorddiagramdialog.cpp" line="47"/>
         <source>Click to edit chord name.</source>
         <translation>Cliquez pour éditer le nom de l&apos;accord.</translation>
     </message>
@@ -626,79 +626,84 @@
         <translation>Aucun accord</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="95"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="702"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="94"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="694"/>
         <source>C</source>
         <translation>Do</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="115"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="722"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="113"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="713"/>
         <source>D</source>
         <translation>Ré</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="135"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="742"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="132"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="732"/>
         <source>E</source>
         <translation>Mi</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="155"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="762"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="151"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="751"/>
         <source>F</source>
         <translation>Fa</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="175"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="782"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="170"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="770"/>
         <source>G</source>
         <translation>Sol</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="195"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="802"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="189"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="789"/>
         <source>A</source>
         <translation>La</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="215"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="822"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="208"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="808"/>
         <source>B</source>
         <translation>Si</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="300"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="293"/>
         <source>Brackets</source>
         <translation>Accolades</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="309"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="302"/>
         <source>Formula:</source>
         <translation>Formule :</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="316"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="309"/>
         <source>Additions:</source>
         <translation>Ajouts :</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="323"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="316"/>
         <source>Extensions:</source>
         <translation>Extensions :</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="330"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="323"/>
         <source>Alterations:</source>
         <translation>Altérations :</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="337"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="330"/>
         <source>Bass Note:</source>
         <translation>Note basse :</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="911"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="892"/>
+        <source>Custom Label</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="907"/>
         <source>Chords in Score:</source>
         <translation>Accords de la partition :</translation>
     </message>
@@ -1863,12 +1868,12 @@
         <translation>Vitesse :</translation>
     </message>
     <message>
-        <location filename="../source/widgets/playback/playbackwidget.ui" line="103"/>
+        <location filename="../source/widgets/playback/playbackwidget.ui" line="109"/>
         <source>Adjusts the current playback speed.</source>
         <translation>Ajuste la vitesse de lecture courante.</translation>
     </message>
     <message>
-        <location filename="../source/widgets/playback/playbackwidget.ui" line="175"/>
+        <location filename="../source/widgets/playback/playbackwidget.ui" line="181"/>
         <source>Zoom:</source>
         <translation>Zoom :</translation>
     </message>
@@ -1925,7 +1930,7 @@
         <translation type="vanished">300%</translation>
     </message>
     <message>
-        <location filename="../source/widgets/playback/playbackwidget.ui" line="220"/>
+        <location filename="../source/widgets/playback/playbackwidget.ui" line="223"/>
         <source>System: 1, Staff: 1, Position: 1, String: 1</source>
         <translation>Système : 1, Portée : 1, Position : 1, Corde : 1</translation>
     </message>
@@ -2002,872 +2007,876 @@
 <context>
     <name>PowerTabEditor</name>
     <message>
-        <location filename="../source/app/clipboard.cpp" line="129"/>
         <source>Cannot paste notes from a different tuning.</source>
-        <translation>Impossible de coller des notes depuis une autre tonalité.</translation>
+        <translation type="vanished">Impossible de coller des notes depuis une autre tonalité.</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="175"/>
+        <location filename="../source/app/powertabeditor.cpp" line="179"/>
         <source>Toolbox</source>
         <translation>Boîte à outils</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="248"/>
+        <location filename="../source/app/powertabeditor.cpp" line="252"/>
         <source>Open</source>
         <translation>Ouvrir</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="278"/>
-        <location filename="../source/app/powertabeditor.cpp" line="303"/>
+        <location filename="../source/app/powertabeditor.cpp" line="282"/>
+        <location filename="../source/app/powertabeditor.cpp" line="307"/>
         <source>Error Opening File</source>
         <translation>Erreur lors de l&apos;ouverture du fichier</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="279"/>
-        <location filename="../source/app/powertabeditor.cpp" line="400"/>
+        <location filename="../source/app/powertabeditor.cpp" line="283"/>
+        <location filename="../source/app/powertabeditor.cpp" line="405"/>
         <source>Unsupported file type.</source>
         <translation>Type de fichier non pris en charge.</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="304"/>
+        <location filename="../source/app/powertabeditor.cpp" line="308"/>
         <source>Error opening file: %1</source>
         <translation>Erreur lors de l&apos;ouverture du fichier : %1</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="337"/>
+        <location filename="../source/app/powertabeditor.cpp" line="342"/>
         <source>Close Document</source>
         <translation>Fermer le document</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="338"/>
+        <location filename="../source/app/powertabeditor.cpp" line="343"/>
         <source>The document has been modified.</source>
         <translation>Le document a été modifié.</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="339"/>
+        <location filename="../source/app/powertabeditor.cpp" line="344"/>
         <source>Do you want to save your changes?</source>
         <translation>Souhaitez-vous enregistrer les modifications ?</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="399"/>
-        <location filename="../source/app/powertabeditor.cpp" line="414"/>
+        <location filename="../source/app/powertabeditor.cpp" line="404"/>
+        <location filename="../source/app/powertabeditor.cpp" line="419"/>
         <source>Error Saving File</source>
         <translation>Erreur lors de l&apos;enregistrement du fichier</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="415"/>
+        <location filename="../source/app/powertabeditor.cpp" line="420"/>
         <source>Error saving file: %1</source>
         <translation>Erreur lors de l&apos;enregistrement du fichier : %1</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="446"/>
+        <location filename="../source/app/powertabeditor.cpp" line="451"/>
         <source>Save As</source>
         <translation>Enregistrer sous</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="538"/>
+        <location filename="../source/app/powertabeditor.cpp" line="544"/>
         <source>Cut Notes</source>
         <translation>Couper les notes</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="554"/>
+        <location filename="../source/app/powertabeditor.cpp" line="560"/>
         <source>The clipboard does not contain any notes.</source>
         <translation>Le presse-papiers ne contient aucune note.</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="559"/>
+        <location filename="../source/app/powertabeditor.cpp" line="565"/>
         <source>Paste Notes</source>
         <translation>Coller les notes</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="604"/>
+        <location filename="../source/app/powertabeditor.cpp" line="618"/>
         <source>Midi Error</source>
         <translation>Erreur MIDI</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="626"/>
+        <location filename="../source/app/powertabeditor.cpp" line="640"/>
         <source>Pause</source>
         <translation>Pause</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="662"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2303"/>
+        <location filename="../source/app/powertabeditor.cpp" line="676"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2382"/>
         <source>Play</source>
         <translation>Lecture</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="885"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2466"/>
+        <location filename="../source/app/powertabeditor.cpp" line="899"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2545"/>
         <source>Remove Position</source>
         <translation>Supprimer la position</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="973"/>
+        <location filename="../source/app/powertabeditor.cpp" line="987"/>
         <source>Edit Chord Text</source>
         <translation>Modifier le texte de l&apos;accord</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1010"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1024"/>
         <source>Edit Text Item</source>
         <translation>Modifier l&apos;élément de texte</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1058"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1072"/>
         <source>Edit Chord Diagram</source>
         <translation>Éditer le diagramme d&apos;accord</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1156"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1170"/>
         <source>Edit Note Duration</source>
         <translation>Modifier la durée de la note</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1386"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1400"/>
         <source>Cannot add a multi-bar rest to a non-empty measure.</source>
         <translation>Impossible d&apos;ajouter un silence multi-mesures à une mesure non vide.</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1399"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1413"/>
         <source>Edit Multi-Bar Rest</source>
         <translation>Modifier le silence multi-mesures</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1476"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1490"/>
         <source>Edit Tempo Marker</source>
         <translation>Modifier le marqueur de tempo</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1515"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1529"/>
         <source>Edit Alteration of Pace</source>
         <translation>Éditer la variation du tempo</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1562"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1576"/>
         <source>Edit Musical Direction</source>
         <translation>Modifier la direction musicale</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1600"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1614"/>
         <source>Edit Repeat Ending</source>
         <translation>Modifier la boucle de fin</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1704"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1718"/>
         <source>Edit Volume Swell</source>
         <translation>Éditer la variation de volume</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1741"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1755"/>
         <source>Edit Tremolo Bar</source>
         <translation>Modifier la mesure de trémolo</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1841"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1855"/>
         <source>Edit Bend</source>
         <translation>Modifier le bend</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1965"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1979"/>
         <source>Edit Player Change</source>
         <translation>Modifier le changement de musicien</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2192"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2264"/>
         <source>Untitled</source>
         <translation>Sans titre</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2205"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2277"/>
         <source>&amp;New</source>
         <translation>Nouveau</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2210"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2282"/>
         <source>&amp;Open...</source>
         <translation>Ouvrir…</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2215"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2287"/>
         <source>&amp;Close Tab</source>
         <translation>Fermer l&apos;onglet</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2220"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2292"/>
         <source>Save</source>
         <translation>Enregistrer</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2226"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2298"/>
         <source>Save As...</source>
         <translation>Enregistrer sous…</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2232"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2304"/>
         <source>Print...</source>
         <translation>Imprimer…</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2238"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2310"/>
         <source>Print Preview...</source>
         <translation>Aperçu avant impression…</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2242"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2315"/>
+        <source>Open Backup Folder...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../source/app/powertabeditor.cpp" line="2321"/>
         <source>Bulk Converter...</source>
         <translation>Convertisseur en masse...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2248"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2327"/>
         <source>Customize Shortcuts...</source>
         <translation>Personnaliser les raccourcis…</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2254"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2333"/>
         <source>&amp;Preferences...</source>
         <translation>Préférences…</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2260"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2339"/>
         <source>&amp;Quit</source>
         <translation>Quitter</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2265"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2344"/>
         <source>&amp;Undo</source>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2268"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2347"/>
         <source>&amp;Redo</source>
         <translation>Rétablir</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2272"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2351"/>
         <source>Cut</source>
         <translation>Couper</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2276"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2355"/>
         <source>Copy</source>
         <translation>Copier</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2281"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2360"/>
         <source>Paste</source>
         <translation>Coller</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2285"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2364"/>
         <source>Polish Score</source>
         <translation>Embellir la partition</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2290"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2369"/>
         <source>Polish System</source>
         <translation>Système d&apos;embellissement</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2297"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2376"/>
         <source>File Information...</source>
         <translation>Informations sur le fichier…</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2315"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2394"/>
         <source>Play From Start Of Measure</source>
         <translation>Jouer depuis le début de la mesure</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2322"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2401"/>
         <source>Stop</source>
         <translation>Arrêter</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2326"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2405"/>
         <source>Rewind</source>
         <translation>Rembobiner</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2331"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2410"/>
         <source>Metronome</source>
         <translation>Métronome</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2337"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2416"/>
         <source>Count-In</source>
         <translation>Compte à rebours</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2345"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2424"/>
         <source>First Section</source>
         <translation>Première section</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2351"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2430"/>
         <source>Next Section</source>
         <translation>Section suivante</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2357"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2436"/>
         <source>Previous Section</source>
         <translation>Section précédente</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2363"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2442"/>
         <source>Last Section</source>
         <translation>Dernière section</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2369"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2448"/>
         <source>Insert Space</source>
         <translation>Insérer un espace</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2375"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2454"/>
         <source>Remove Space</source>
         <translation>Supprimer l&apos;espace</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2391"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2470"/>
         <source>Move to &amp;Start</source>
         <translation>Aller au début</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2397"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2476"/>
         <source>&amp;Next Position</source>
         <translation>Position suivante</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2403"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2482"/>
         <source>&amp;Previous Position</source>
         <translation>Position précédente</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2409"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2488"/>
         <source>Next String</source>
         <translation>Corde suivante</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2415"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2494"/>
         <source>Previous String</source>
         <translation>Corde précédente</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2421"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2500"/>
         <source>Move to &amp;End</source>
         <translation>Aller à la fin</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2427"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2506"/>
         <source>Next Staff</source>
         <translation>Portée suivante</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2433"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2512"/>
         <source>Previous Staff</source>
         <translation>Portée précédente</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2438"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2517"/>
         <source>Next Bar</source>
         <translation>Barre suivante</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2444"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2523"/>
         <source>Previous Bar</source>
         <translation>Barre précédente</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2460"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2539"/>
         <source>Remove Selected Item</source>
         <translation>Supprimer l&apos;élément sélectionné</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2471"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2550"/>
         <source>Go To Barline...</source>
         <translation>Aller à la barre de mesure…</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2477"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2556"/>
         <source>Go To Rehearsal Sign...</source>
         <translation>Aller au signe de répétition…</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2484"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2563"/>
         <source>Chord Name...</source>
         <translation>Nom de l&apos;accord…</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2490"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2569"/>
         <source>Text...</source>
         <translation>Texte…</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2498"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2577"/>
         <source>Add Chord Diagram...</source>
         <translation>Ajouter un diagramme d&apos;accord...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2503"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2582"/>
         <source>Insert System At End</source>
         <translation>Insérer un système à la fin</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2509"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2588"/>
         <source>Insert System Before</source>
         <translation>Insérer un système avant</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2516"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2595"/>
         <source>Insert System After</source>
         <translation>Insérer un système après</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2523"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2602"/>
         <source>Remove Current System</source>
         <translation>Supprimer le système courant</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2531"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2610"/>
         <source>Insert Staff Before</source>
         <translation>Insérer une portée avant</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2537"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2616"/>
         <source>Insert Staff After</source>
         <translation>Insérer une portée après</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2543"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2622"/>
         <source>Remove Current Staff</source>
         <translation>Supprimer la portée courante</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2548"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2627"/>
         <source>Increase</source>
         <translation>Augmenter</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2555"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2634"/>
         <source>Decrease</source>
         <translation>Diminuer</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2564"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2707"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2643"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2786"/>
         <source>Whole</source>
         <translation>Ronde</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2567"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2709"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2646"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2788"/>
         <source>Half</source>
         <translation>Blanche</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2570"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2711"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2649"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2790"/>
         <source>Quarter</source>
         <translation>Noire</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2573"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2713"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2652"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2792"/>
         <source>8th</source>
         <translation>Croche</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2576"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2715"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2655"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2794"/>
         <source>16th</source>
         <translation>Double croche</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2579"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2717"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2658"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2796"/>
         <source>32nd</source>
         <translation>Triple croche</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2583"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2720"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2662"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2799"/>
         <source>64th</source>
         <translation>Quadruple croche</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2588"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2667"/>
         <source>Increase Duration</source>
         <translation>Augmenter la durée</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2595"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2674"/>
         <source>Decrease Duration</source>
         <translation>Diminuer la durée</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2602"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2681"/>
         <source>Dotted</source>
         <translation>Pointée</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2606"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2685"/>
         <source>Double Dotted</source>
         <translation>Pointée double</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2611"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2690"/>
         <source>Add Dot</source>
         <translation>Ajouter un point</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2615"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2694"/>
         <source>Remove Dot</source>
         <translation>Supprimer un point</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2619"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2698"/>
         <source>Left Hand Fingering...</source>
         <translation>Doigté main gauche…</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2628"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2707"/>
         <source>Shift String Up</source>
         <translation>Décaler sur la corde supérieure</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2634"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2713"/>
         <source>Shift String Down</source>
         <translation>Décaler sur la corde inférieure</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2639"/>
-        <location filename="../source/app/powertabeditor.cpp" line="3933"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2718"/>
+        <location filename="../source/app/powertabeditor.cpp" line="4010"/>
         <source>Tied</source>
         <translation>Liée</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2644"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2723"/>
         <source>Muted</source>
         <translation>Muette</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2647"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2726"/>
         <source>Ghost Note</source>
         <translation>Note fantôme</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2651"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2730"/>
         <source>Fermata</source>
         <translation>Point d&apos;orgue</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2655"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2734"/>
         <source>Let Ring</source>
         <translation>Laisser sonner</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2659"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2738"/>
         <source>Grace Note</source>
         <translation>Appoggiature</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2664"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2743"/>
         <source>Staccato</source>
         <translation>Staccato</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2668"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2747"/>
         <source>Accent</source>
         <translation>Accent</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2672"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2751"/>
         <source>Heavy Accent</source>
         <translation>Accent fort</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2678"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2757"/>
         <source>8va</source>
         <translation>8va</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2681"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2760"/>
         <source>15ma</source>
         <translation>15ma</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2684"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2763"/>
         <source>8vb</source>
         <translation>8vb</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2687"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2766"/>
         <source>15mb</source>
         <translation>15mb</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2691"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2770"/>
         <source>Triplet</source>
         <translation>Triolet</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2698"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2777"/>
         <source>Irregular Grouping</source>
         <translation>Groupe irrégulier</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2724"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2803"/>
         <source>Add Rest</source>
         <translation>Ajouter un silence</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2730"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2809"/>
         <source>Multi-Bar Rest...</source>
         <translation>Silence multi-mesures…</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2738"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2817"/>
         <source>Rehearsal Sign...</source>
         <translation>Signe de répétition…</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2745"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2824"/>
         <source>Tempo Marker...</source>
         <translation>Marqueur de tempo…</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2752"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2831"/>
         <source>Alteration of Pace...</source>
         <translation>Variation de nuance...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2758"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2837"/>
         <source>Edit Key Signature...</source>
         <translation>Modifier l&apos;armure...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2765"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2844"/>
         <source>Edit Time Signature...</source>
         <translation>Modifier la signature rythmique...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2772"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2851"/>
         <source>Insert Standard Barline</source>
         <translation>Insérer une barre de mesure standard</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2779"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2858"/>
         <source>Barline...</source>
         <translation>Barre de mesure…</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2785"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2864"/>
         <source>Musical Direction...</source>
         <translation>Direction musicale…</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2793"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2872"/>
         <source>Repeat Ending...</source>
         <translation>Boucle de fin…</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2801"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2880"/>
         <source>Dynamic...</source>
         <translation>Nuance…</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2808"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2811"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2814"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2817"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2820"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2823"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2826"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2829"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2887"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2890"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2893"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2896"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2899"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2902"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2905"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2908"/>
         <source>Dynamics</source>
         <translation>Nuances</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2834"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2913"/>
         <source>Volume Swell...</source>
         <translation>Variation de volume...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2841"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2920"/>
         <source>Hammer On/Pull Off</source>
         <translation>Hammer On/Pull Off</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2849"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2928"/>
         <source>Hammer On From Nowhere</source>
         <translation>Hammer-on de nulle part</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2854"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2933"/>
         <source>Pull Off To Nowhere</source>
         <translation>Pull-off de nulle part</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2858"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2937"/>
         <source>Natural Harmonic</source>
         <translation>Harmonique naturel</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2863"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2942"/>
         <source>Artificial Harmonic...</source>
         <translation>Harmonique artificiel…</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2870"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2949"/>
         <source>Tapped Harmonic...</source>
         <translation>Harmonique tapé...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2879"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2958"/>
         <source>Bend...</source>
         <translation>Bend…</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2886"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2965"/>
         <source>Tremolo Bar...</source>
         <translation>Mesure de trémolo…</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2892"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2971"/>
         <source>Vibrato</source>
         <translation>Vibrato</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2897"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2976"/>
         <source>Wide Vibrato</source>
         <translation>Vibrato large</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2902"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2981"/>
         <source>Palm Mute</source>
         <translation>Palm mute</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2906"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2985"/>
         <source>Tremolo Picking</source>
         <translation>Picking trémolo</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2910"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2989"/>
         <source>Arpeggio Up</source>
         <translation>Arpège ascendant</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2915"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2994"/>
         <source>Arpeggio Down</source>
         <translation>Arpège descendant</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2920"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2999"/>
         <source>Tap</source>
         <translation>Taper</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2924"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3003"/>
         <source>Trill...</source>
         <translation>Trille…</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2930"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3009"/>
         <source>Pickstroke Up</source>
         <translation>Jouer vers le haut</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2935"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3014"/>
         <source>Pickstroke Down</source>
         <translation>Jouer vers le bas</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2941"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3020"/>
         <source>Slide Into From Above</source>
         <translation>Glissé d&apos;entrée par le haut</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2946"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3025"/>
         <source>Slide Into From Below</source>
         <translation>Glissé d&apos;entrée par le bas</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2951"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3030"/>
         <source>Shift Slide</source>
         <translation>Glissé</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2955"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3034"/>
         <source>Legato Slide</source>
         <translation>Glissé avec liaison</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2961"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3040"/>
         <source>Slide Out Of Downwards</source>
         <translation>Glissé de sortie vers le bas</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2966"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3045"/>
         <source>Slide Out Of Upwards</source>
         <translation>Glissé de sortie vers le haut</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2973"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3052"/>
         <source>Add Player</source>
         <translation>Ajouter un musicien</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2978"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3057"/>
         <source>Add Instrument</source>
         <translation>Ajouter un instrument</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2982"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3061"/>
         <source>Player Change...</source>
         <translation>Changement de musicien…</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2989"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3068"/>
         <source>Tuning Dictionary...</source>
         <translation>Dictionnaire de tonalités…</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2996"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3075"/>
         <source>Edit View Filters...</source>
         <translation>Éditer les filtres...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3013"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3092"/>
         <source>Next Tab</source>
         <translation>Tablature suivante</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3019"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3098"/>
         <source>Previous Tab</source>
         <translation>Tablature précédente</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3033"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3112"/>
         <source>Zoom In</source>
         <translation>Zoomer</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3038"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3117"/>
         <source>Zoom Out</source>
         <translation>Dézoomer</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3044"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3123"/>
         <source>Report Bug...</source>
         <translation>Signaler un problème…</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3050"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3129"/>
         <source>Translate This Application...</source>
         <translation>Traduire cette application...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3056"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3135"/>
         <source>Application Info...</source>
         <translation>Informations sur l&apos;application...</translation>
     </message>
@@ -2876,145 +2885,150 @@
         <translation type="vanished">Informations sur l&apos;application</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3100"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3179"/>
         <source>Mixer</source>
         <translation>Mélangeur</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3125"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3204"/>
         <source>Instruments</source>
         <translation>Instruments</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3228"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3307"/>
         <source>&amp;File</source>
         <translation>Fichier</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3239"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3318"/>
         <source>Recent Files</source>
         <translation>Fichiers récents</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3249"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3329"/>
         <source>&amp;Edit</source>
         <translation>Édition</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3265"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3345"/>
         <source>Play&amp;back</source>
         <translation>Lecture</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3274"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3354"/>
         <source>&amp;Position</source>
         <translation>Position</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3275"/>
-        <location filename="../source/app/powertabeditor.cpp" line="3311"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3355"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3391"/>
         <source>&amp;Section</source>
         <translation>Section</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3281"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3361"/>
         <source>&amp;Staff</source>
         <translation>Portée</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3304"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3384"/>
         <source>&amp;Text</source>
         <translation>Texte</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3321"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3401"/>
         <source>&amp;Line Spacing</source>
         <translation>Interligne</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3326"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3406"/>
         <source>&amp;Notes</source>
         <translation>Notes</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3360"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3440"/>
         <source>Octave</source>
         <translation>Octave</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3370"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3450"/>
         <source>Rests</source>
         <translation>Silences</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3383"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3463"/>
         <source>&amp;Music Symbols</source>
         <translation>Symboles musicaux</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3397"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3477"/>
         <source>&amp;Tab Symbols</source>
         <translation>Symboles de tablature</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3398"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3478"/>
         <source>&amp;Hammer Ons/Pull Offs</source>
         <translation>Hammer Ons/Pull Offs</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3412"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3492"/>
         <source>Slide Into</source>
         <translation>Glissé d&apos;entrée</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3419"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3499"/>
         <source>Slide Out Of</source>
         <translation>Glissé de sortie</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3439"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3519"/>
         <source>&amp;Player</source>
         <translation>Musicien</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3448"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3528"/>
         <source>&amp;Window</source>
         <translation>Fenêtre</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3459"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3539"/>
         <source>&amp;Help</source>
         <translation>Aide</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3939"/>
+        <location filename="../source/app/powertabeditor.cpp" line="4016"/>
         <source>Insert Tied Note</source>
         <translation>Insérer une note liée</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="4034"/>
+        <location filename="../source/app/powertabeditor.cpp" line="4111"/>
         <source>Edit Barline</source>
         <translation>Modifier la barre de mesure</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="4039"/>
+        <location filename="../source/app/powertabeditor.cpp" line="4116"/>
         <source>Insert Barline</source>
         <translation>Insérer une barre de mesure</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="4045"/>
+        <location filename="../source/app/powertabeditor.cpp" line="4122"/>
         <source>Barline</source>
         <translation>Barre de mesure</translation>
     </message>
     <message>
-        <location filename="../source/build/main.cpp" line="201"/>
+        <location filename="../source/build/main.cpp" line="191"/>
         <source>A guitar tablature editor.</source>
         <translation>Un éditeur de tablatures de guitare.</translation>
     </message>
     <message>
-        <location filename="../source/build/main.cpp" line="207"/>
+        <location filename="../source/build/main.cpp" line="197"/>
         <source>The files to be opened</source>
         <translation>Les fichiers à ouvrir</translation>
+    </message>
+    <message>
+        <location filename="../source/app/clipboard.cpp" line="130"/>
+        <source>Cannot paste notes from a different number of strings.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3050,9 +3064,13 @@
         <translation>Force du vibrato large :</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/preferencesdialog.ui" line="86"/>
         <source>Play Notes While Editing</source>
-        <translation>Jouer les notes pendant l&apos;édition</translation>
+        <translation type="vanished">Jouer les notes pendant l&apos;édition</translation>
+    </message>
+    <message>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="86"/>
+        <source>Play Notes While Editing:</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../source/dialogs/preferencesdialog.ui" line="101"/>
@@ -3068,7 +3086,7 @@
     <message>
         <location filename="../source/dialogs/preferencesdialog.ui" line="122"/>
         <location filename="../source/dialogs/preferencesdialog.ui" line="193"/>
-        <location filename="../source/dialogs/preferencesdialog.ui" line="322"/>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="355"/>
         <source>Preset:</source>
         <translation>Préréglage :</translation>
     </message>
@@ -3133,27 +3151,42 @@
         <translation>Espacement des systèmes :</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/preferencesdialog.ui" line="297"/>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="296"/>
+        <source>Backup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="304"/>
+        <source>Enable Auto Backup:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="314"/>
+        <source>Backup Interval (seconds):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="330"/>
         <source>Default Instrument</source>
         <translation>Instrument par défaut</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/preferencesdialog.ui" line="312"/>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="345"/>
         <source>Name:</source>
         <translation>Nom :</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/preferencesdialog.ui" line="332"/>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="365"/>
         <source>Tuning:</source>
         <translation>Tonalité :</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/preferencesdialog.ui" line="339"/>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="372"/>
         <source>Tuning</source>
         <translation>Tonalité</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/preferencesdialog.cpp" line="146"/>
+        <location filename="../source/dialogs/preferencesdialog.cpp" line="148"/>
         <source>Click to adjust tuning.</source>
         <translation>Cliquez pour ajuster la tonalité.</translation>
     </message>
@@ -3313,7 +3346,7 @@
         <translation>Supprimer la position</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1355"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1369"/>
         <source>Remove Multi-Bar Rest</source>
         <translation>Supprimer le silence multi-mesures</translation>
     </message>
@@ -3426,67 +3459,67 @@
         <translation>Double-cliquez pour modifier les informations de la partition.</translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="155"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="150"/>
         <source>Double-click to change clef type.</source>
         <translation>Double-cliquez pour modifier le type de clé.</translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="197"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="192"/>
         <source>Double-click to edit the number of strings.</source>
         <translation>Double-cliquez pour modifier le nombre de cordes.</translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="304"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="298"/>
         <source>Double-click to edit rehearsal sign.</source>
         <translation>Double-cliquez pour modifier le signe de répétition.</translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="507"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="500"/>
         <source>Double-click to edit repeat endings.</source>
         <translation>Double-cliquez pour modifier les boucles de fin.</translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="638"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="634"/>
         <source>Double-click to edit tempo marker.</source>
         <translation>Double-cliquez pour modifier le marqueur de tempo.</translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="745"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="741"/>
         <source>Double-click to edit chord text.</source>
         <translation>Double-cliquez pour modifier le texte de l&apos;accord.</translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="771"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="767"/>
         <source>Double-click to edit text.</source>
         <translation>Double-cliquez pour modifier le texte.</translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="941"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="937"/>
         <source>Double-click to edit the active players.</source>
         <translation>Double-cliquez pour modifier les musiciens actifs.</translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="1394"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="1389"/>
         <source>Double-click to edit volume swell.</source>
         <translation>Double-cliquez pour éditer la variation de volume.</translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="1414"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="1409"/>
         <source>Double-click to edit tremolo bar.</source>
         <translation>Double-cliquez pour modifier la mesure de trémolo.</translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="1589"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="1583"/>
         <source>Double-click to edit dynamic.</source>
         <translation>Double-cliquez pour modifier la nuance.</translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="1932"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="1926"/>
         <source>Double-click to edit multi-bar rest.</source>
         <translation>Double-cliquez pour modifier le silence multi-mesures.</translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="2185"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="2178"/>
         <source>Double-click to edit bend.</source>
         <translation>Double-cliquez pour modifier le bend.</translation>
     </message>

--- a/translations/powertabeditor_it.ts
+++ b/translations/powertabeditor_it.ts
@@ -531,12 +531,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/bulkconverterdialog.cpp" line="172"/>
+        <location filename="../source/dialogs/bulkconverterdialog.cpp" line="170"/>
         <source>Convert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/bulkconverterdialog.cpp" line="190"/>
+        <location filename="../source/dialogs/bulkconverterdialog.cpp" line="188"/>
         <source>Directory To Convert</source>
         <translation type="unfinished"></translation>
     </message>
@@ -582,7 +582,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chorddiagramdialog.cpp" line="48"/>
+        <location filename="../source/dialogs/chorddiagramdialog.cpp" line="47"/>
         <source>Click to edit chord name.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -610,79 +610,84 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="95"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="702"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="94"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="694"/>
         <source>C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="115"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="722"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="113"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="713"/>
         <source>D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="135"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="742"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="132"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="732"/>
         <source>E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="155"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="762"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="151"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="751"/>
         <source>F</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="175"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="782"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="170"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="770"/>
         <source>G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="195"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="802"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="189"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="789"/>
         <source>A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="215"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="822"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="208"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="808"/>
         <source>B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="300"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="293"/>
         <source>Brackets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="309"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="302"/>
         <source>Formula:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="316"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="309"/>
         <source>Additions:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="323"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="316"/>
         <source>Extensions:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="330"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="323"/>
         <source>Alterations:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="337"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="330"/>
         <source>Bass Note:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="911"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="892"/>
+        <source>Custom Label</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="907"/>
         <source>Chords in Score:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1846,17 +1851,17 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/widgets/playback/playbackwidget.ui" line="103"/>
+        <location filename="../source/widgets/playback/playbackwidget.ui" line="109"/>
         <source>Adjusts the current playback speed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/widgets/playback/playbackwidget.ui" line="175"/>
+        <location filename="../source/widgets/playback/playbackwidget.ui" line="181"/>
         <source>Zoom:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/widgets/playback/playbackwidget.ui" line="220"/>
+        <location filename="../source/widgets/playback/playbackwidget.ui" line="223"/>
         <source>System: 1, Staff: 1, Position: 1, String: 1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1933,1014 +1938,1019 @@
 <context>
     <name>PowerTabEditor</name>
     <message>
-        <location filename="../source/app/clipboard.cpp" line="129"/>
-        <source>Cannot paste notes from a different tuning.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../source/app/powertabeditor.cpp" line="175"/>
+        <location filename="../source/app/powertabeditor.cpp" line="179"/>
         <source>Toolbox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="248"/>
+        <location filename="../source/app/powertabeditor.cpp" line="252"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="278"/>
-        <location filename="../source/app/powertabeditor.cpp" line="303"/>
+        <location filename="../source/app/powertabeditor.cpp" line="282"/>
+        <location filename="../source/app/powertabeditor.cpp" line="307"/>
         <source>Error Opening File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="279"/>
-        <location filename="../source/app/powertabeditor.cpp" line="400"/>
+        <location filename="../source/app/powertabeditor.cpp" line="283"/>
+        <location filename="../source/app/powertabeditor.cpp" line="405"/>
         <source>Unsupported file type.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="304"/>
+        <location filename="../source/app/powertabeditor.cpp" line="308"/>
         <source>Error opening file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="337"/>
+        <location filename="../source/app/powertabeditor.cpp" line="342"/>
         <source>Close Document</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="338"/>
+        <location filename="../source/app/powertabeditor.cpp" line="343"/>
         <source>The document has been modified.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="339"/>
+        <location filename="../source/app/powertabeditor.cpp" line="344"/>
         <source>Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="399"/>
-        <location filename="../source/app/powertabeditor.cpp" line="414"/>
+        <location filename="../source/app/powertabeditor.cpp" line="404"/>
+        <location filename="../source/app/powertabeditor.cpp" line="419"/>
         <source>Error Saving File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="415"/>
+        <location filename="../source/app/powertabeditor.cpp" line="420"/>
         <source>Error saving file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="446"/>
+        <location filename="../source/app/powertabeditor.cpp" line="451"/>
         <source>Save As</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="538"/>
+        <location filename="../source/app/powertabeditor.cpp" line="544"/>
         <source>Cut Notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="554"/>
+        <location filename="../source/app/powertabeditor.cpp" line="560"/>
         <source>The clipboard does not contain any notes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="559"/>
+        <location filename="../source/app/powertabeditor.cpp" line="565"/>
         <source>Paste Notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="604"/>
+        <location filename="../source/app/powertabeditor.cpp" line="618"/>
         <source>Midi Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="626"/>
+        <location filename="../source/app/powertabeditor.cpp" line="640"/>
         <source>Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="662"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2303"/>
+        <location filename="../source/app/powertabeditor.cpp" line="676"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2382"/>
         <source>Play</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="885"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2466"/>
+        <location filename="../source/app/powertabeditor.cpp" line="899"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2545"/>
         <source>Remove Position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="973"/>
+        <location filename="../source/app/powertabeditor.cpp" line="987"/>
         <source>Edit Chord Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1010"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1024"/>
         <source>Edit Text Item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1058"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1072"/>
         <source>Edit Chord Diagram</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1156"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1170"/>
         <source>Edit Note Duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1386"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1400"/>
         <source>Cannot add a multi-bar rest to a non-empty measure.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1399"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1413"/>
         <source>Edit Multi-Bar Rest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1476"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1490"/>
         <source>Edit Tempo Marker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1515"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1529"/>
         <source>Edit Alteration of Pace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1562"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1576"/>
         <source>Edit Musical Direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1600"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1614"/>
         <source>Edit Repeat Ending</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1704"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1718"/>
         <source>Edit Volume Swell</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1741"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1755"/>
         <source>Edit Tremolo Bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1841"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1855"/>
         <source>Edit Bend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1965"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1979"/>
         <source>Edit Player Change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2192"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2264"/>
         <source>Untitled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2205"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2277"/>
         <source>&amp;New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2210"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2282"/>
         <source>&amp;Open...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2215"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2287"/>
         <source>&amp;Close Tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2220"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2292"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2226"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2298"/>
         <source>Save As...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2232"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2304"/>
         <source>Print...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2238"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2310"/>
         <source>Print Preview...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2242"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2315"/>
+        <source>Open Backup Folder...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../source/app/powertabeditor.cpp" line="2321"/>
         <source>Bulk Converter...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2248"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2327"/>
         <source>Customize Shortcuts...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2254"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2333"/>
         <source>&amp;Preferences...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2260"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2339"/>
         <source>&amp;Quit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2265"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2344"/>
         <source>&amp;Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2268"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2347"/>
         <source>&amp;Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2272"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2351"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2276"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2355"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2281"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2360"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2285"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2364"/>
         <source>Polish Score</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2290"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2369"/>
         <source>Polish System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2297"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2376"/>
         <source>File Information...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2315"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2394"/>
         <source>Play From Start Of Measure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2322"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2401"/>
         <source>Stop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2326"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2405"/>
         <source>Rewind</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2331"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2410"/>
         <source>Metronome</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2337"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2416"/>
         <source>Count-In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2345"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2424"/>
         <source>First Section</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2351"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2430"/>
         <source>Next Section</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2357"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2436"/>
         <source>Previous Section</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2363"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2442"/>
         <source>Last Section</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2369"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2448"/>
         <source>Insert Space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2375"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2454"/>
         <source>Remove Space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2391"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2470"/>
         <source>Move to &amp;Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2397"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2476"/>
         <source>&amp;Next Position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2403"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2482"/>
         <source>&amp;Previous Position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2409"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2488"/>
         <source>Next String</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2415"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2494"/>
         <source>Previous String</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2421"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2500"/>
         <source>Move to &amp;End</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2427"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2506"/>
         <source>Next Staff</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2433"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2512"/>
         <source>Previous Staff</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2438"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2517"/>
         <source>Next Bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2444"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2523"/>
         <source>Previous Bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2460"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2539"/>
         <source>Remove Selected Item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2471"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2550"/>
         <source>Go To Barline...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2477"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2556"/>
         <source>Go To Rehearsal Sign...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2484"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2563"/>
         <source>Chord Name...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2490"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2569"/>
         <source>Text...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2498"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2577"/>
         <source>Add Chord Diagram...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2503"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2582"/>
         <source>Insert System At End</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2509"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2588"/>
         <source>Insert System Before</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2516"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2595"/>
         <source>Insert System After</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2523"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2602"/>
         <source>Remove Current System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2531"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2610"/>
         <source>Insert Staff Before</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2537"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2616"/>
         <source>Insert Staff After</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2543"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2622"/>
         <source>Remove Current Staff</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2548"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2627"/>
         <source>Increase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2555"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2634"/>
         <source>Decrease</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2564"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2707"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2643"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2786"/>
         <source>Whole</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2567"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2709"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2646"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2788"/>
         <source>Half</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2570"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2711"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2649"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2790"/>
         <source>Quarter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2573"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2713"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2652"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2792"/>
         <source>8th</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2576"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2715"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2655"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2794"/>
         <source>16th</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2579"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2717"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2658"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2796"/>
         <source>32nd</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2583"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2720"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2662"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2799"/>
         <source>64th</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2588"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2667"/>
         <source>Increase Duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2595"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2674"/>
         <source>Decrease Duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2602"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2681"/>
         <source>Dotted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2606"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2685"/>
         <source>Double Dotted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2611"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2690"/>
         <source>Add Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2615"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2694"/>
         <source>Remove Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2619"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2698"/>
         <source>Left Hand Fingering...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2628"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2707"/>
         <source>Shift String Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2634"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2713"/>
         <source>Shift String Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2639"/>
-        <location filename="../source/app/powertabeditor.cpp" line="3933"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2718"/>
+        <location filename="../source/app/powertabeditor.cpp" line="4010"/>
         <source>Tied</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2644"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2723"/>
         <source>Muted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2647"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2726"/>
         <source>Ghost Note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2651"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2730"/>
         <source>Fermata</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2655"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2734"/>
         <source>Let Ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2659"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2738"/>
         <source>Grace Note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2664"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2743"/>
         <source>Staccato</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2668"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2747"/>
         <source>Accent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2672"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2751"/>
         <source>Heavy Accent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2678"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2757"/>
         <source>8va</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2681"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2760"/>
         <source>15ma</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2684"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2763"/>
         <source>8vb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2687"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2766"/>
         <source>15mb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2691"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2770"/>
         <source>Triplet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2698"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2777"/>
         <source>Irregular Grouping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2724"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2803"/>
         <source>Add Rest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2730"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2809"/>
         <source>Multi-Bar Rest...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2738"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2817"/>
         <source>Rehearsal Sign...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2745"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2824"/>
         <source>Tempo Marker...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2752"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2831"/>
         <source>Alteration of Pace...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2758"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2837"/>
         <source>Edit Key Signature...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2765"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2844"/>
         <source>Edit Time Signature...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2772"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2851"/>
         <source>Insert Standard Barline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2779"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2858"/>
         <source>Barline...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2785"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2864"/>
         <source>Musical Direction...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2793"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2872"/>
         <source>Repeat Ending...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2801"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2880"/>
         <source>Dynamic...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2808"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2811"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2814"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2817"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2820"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2823"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2826"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2829"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2887"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2890"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2893"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2896"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2899"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2902"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2905"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2908"/>
         <source>Dynamics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2834"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2913"/>
         <source>Volume Swell...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2841"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2920"/>
         <source>Hammer On/Pull Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2849"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2928"/>
         <source>Hammer On From Nowhere</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2854"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2933"/>
         <source>Pull Off To Nowhere</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2858"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2937"/>
         <source>Natural Harmonic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2863"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2942"/>
         <source>Artificial Harmonic...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2870"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2949"/>
         <source>Tapped Harmonic...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2879"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2958"/>
         <source>Bend...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2886"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2965"/>
         <source>Tremolo Bar...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2892"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2971"/>
         <source>Vibrato</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2897"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2976"/>
         <source>Wide Vibrato</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2902"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2981"/>
         <source>Palm Mute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2906"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2985"/>
         <source>Tremolo Picking</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2910"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2989"/>
         <source>Arpeggio Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2915"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2994"/>
         <source>Arpeggio Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2920"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2999"/>
         <source>Tap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2924"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3003"/>
         <source>Trill...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2930"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3009"/>
         <source>Pickstroke Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2935"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3014"/>
         <source>Pickstroke Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2941"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3020"/>
         <source>Slide Into From Above</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2946"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3025"/>
         <source>Slide Into From Below</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2951"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3030"/>
         <source>Shift Slide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2955"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3034"/>
         <source>Legato Slide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2961"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3040"/>
         <source>Slide Out Of Downwards</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2966"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3045"/>
         <source>Slide Out Of Upwards</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2973"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3052"/>
         <source>Add Player</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2978"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3057"/>
         <source>Add Instrument</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2982"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3061"/>
         <source>Player Change...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2989"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3068"/>
         <source>Tuning Dictionary...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2996"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3075"/>
         <source>Edit View Filters...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3013"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3092"/>
         <source>Next Tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3019"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3098"/>
         <source>Previous Tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3033"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3112"/>
         <source>Zoom In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3038"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3117"/>
         <source>Zoom Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3044"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3123"/>
         <source>Report Bug...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3050"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3129"/>
         <source>Translate This Application...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3056"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3135"/>
         <source>Application Info...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3100"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3179"/>
         <source>Mixer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3125"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3204"/>
         <source>Instruments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3228"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3307"/>
         <source>&amp;File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3239"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3318"/>
         <source>Recent Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3249"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3329"/>
         <source>&amp;Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3265"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3345"/>
         <source>Play&amp;back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3274"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3354"/>
         <source>&amp;Position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3275"/>
-        <location filename="../source/app/powertabeditor.cpp" line="3311"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3355"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3391"/>
         <source>&amp;Section</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3281"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3361"/>
         <source>&amp;Staff</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3304"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3384"/>
         <source>&amp;Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3321"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3401"/>
         <source>&amp;Line Spacing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3326"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3406"/>
         <source>&amp;Notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3360"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3440"/>
         <source>Octave</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3370"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3450"/>
         <source>Rests</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3383"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3463"/>
         <source>&amp;Music Symbols</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3397"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3477"/>
         <source>&amp;Tab Symbols</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3398"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3478"/>
         <source>&amp;Hammer Ons/Pull Offs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3412"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3492"/>
         <source>Slide Into</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3419"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3499"/>
         <source>Slide Out Of</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3439"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3519"/>
         <source>&amp;Player</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3448"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3528"/>
         <source>&amp;Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3459"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3539"/>
         <source>&amp;Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3939"/>
+        <location filename="../source/app/powertabeditor.cpp" line="4016"/>
         <source>Insert Tied Note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="4034"/>
+        <location filename="../source/app/powertabeditor.cpp" line="4111"/>
         <source>Edit Barline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="4039"/>
+        <location filename="../source/app/powertabeditor.cpp" line="4116"/>
         <source>Insert Barline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="4045"/>
+        <location filename="../source/app/powertabeditor.cpp" line="4122"/>
         <source>Barline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/build/main.cpp" line="201"/>
+        <location filename="../source/build/main.cpp" line="191"/>
         <source>A guitar tablature editor.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/build/main.cpp" line="207"/>
+        <location filename="../source/build/main.cpp" line="197"/>
         <source>The files to be opened</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../source/app/clipboard.cpp" line="130"/>
+        <source>Cannot paste notes from a different number of strings.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2978,7 +2988,7 @@
     </message>
     <message>
         <location filename="../source/dialogs/preferencesdialog.ui" line="86"/>
-        <source>Play Notes While Editing</source>
+        <source>Play Notes While Editing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2995,7 +3005,7 @@
     <message>
         <location filename="../source/dialogs/preferencesdialog.ui" line="122"/>
         <location filename="../source/dialogs/preferencesdialog.ui" line="193"/>
-        <location filename="../source/dialogs/preferencesdialog.ui" line="322"/>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="355"/>
         <source>Preset:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3060,27 +3070,42 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/preferencesdialog.ui" line="297"/>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="296"/>
+        <source>Backup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="304"/>
+        <source>Enable Auto Backup:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="314"/>
+        <source>Backup Interval (seconds):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="330"/>
         <source>Default Instrument</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/preferencesdialog.ui" line="312"/>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="345"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/preferencesdialog.ui" line="332"/>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="365"/>
         <source>Tuning:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/preferencesdialog.ui" line="339"/>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="372"/>
         <source>Tuning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/preferencesdialog.cpp" line="146"/>
+        <location filename="../source/dialogs/preferencesdialog.cpp" line="148"/>
         <source>Click to adjust tuning.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3240,7 +3265,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1355"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1369"/>
         <source>Remove Multi-Bar Rest</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3353,67 +3378,67 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="155"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="150"/>
         <source>Double-click to change clef type.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="197"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="192"/>
         <source>Double-click to edit the number of strings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="304"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="298"/>
         <source>Double-click to edit rehearsal sign.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="507"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="500"/>
         <source>Double-click to edit repeat endings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="638"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="634"/>
         <source>Double-click to edit tempo marker.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="745"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="741"/>
         <source>Double-click to edit chord text.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="771"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="767"/>
         <source>Double-click to edit text.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="941"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="937"/>
         <source>Double-click to edit the active players.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="1394"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="1389"/>
         <source>Double-click to edit volume swell.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="1414"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="1409"/>
         <source>Double-click to edit tremolo bar.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="1589"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="1583"/>
         <source>Double-click to edit dynamic.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="1932"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="1926"/>
         <source>Double-click to edit multi-bar rest.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="2185"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="2178"/>
         <source>Double-click to edit bend.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/powertabeditor_ja.ts
+++ b/translations/powertabeditor_ja.ts
@@ -547,12 +547,12 @@
         <translation type="vanished">変換元ディレクトリ</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/bulkconverterdialog.cpp" line="172"/>
+        <location filename="../source/dialogs/bulkconverterdialog.cpp" line="170"/>
         <source>Convert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/bulkconverterdialog.cpp" line="190"/>
+        <location filename="../source/dialogs/bulkconverterdialog.cpp" line="188"/>
         <source>Directory To Convert</source>
         <translation>変換ディレクトリ</translation>
     </message>
@@ -598,7 +598,7 @@
         <translation>ダイアグラム:</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chorddiagramdialog.cpp" line="48"/>
+        <location filename="../source/dialogs/chorddiagramdialog.cpp" line="47"/>
         <source>Click to edit chord name.</source>
         <translation>クリックでコードネームを編集できます。</translation>
     </message>
@@ -626,79 +626,84 @@
         <translation>ノーコード(N.C.)</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="95"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="702"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="94"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="694"/>
         <source>C</source>
         <translation>C</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="115"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="722"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="113"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="713"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="135"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="742"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="132"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="732"/>
         <source>E</source>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="155"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="762"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="151"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="751"/>
         <source>F</source>
         <translation>F</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="175"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="782"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="170"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="770"/>
         <source>G</source>
         <translation>G</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="195"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="802"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="189"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="789"/>
         <source>A</source>
         <translation>A</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="215"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="822"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="208"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="808"/>
         <source>B</source>
         <translation>B</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="300"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="293"/>
         <source>Brackets</source>
         <translation>括弧</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="309"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="302"/>
         <source>Formula:</source>
         <translation>種類:</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="316"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="309"/>
         <source>Additions:</source>
         <translation>add:</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="323"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="316"/>
         <source>Extensions:</source>
         <translation>エクステンション:</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="330"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="323"/>
         <source>Alterations:</source>
         <translation>オルタネーション:</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="337"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="330"/>
         <source>Bass Note:</source>
         <translation>ルート音:</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="911"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="892"/>
+        <source>Custom Label</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="907"/>
         <source>Chords in Score:</source>
         <translation>スコア内のコード:</translation>
     </message>
@@ -1863,17 +1868,17 @@
         <translation>スピード:</translation>
     </message>
     <message>
-        <location filename="../source/widgets/playback/playbackwidget.ui" line="103"/>
+        <location filename="../source/widgets/playback/playbackwidget.ui" line="109"/>
         <source>Adjusts the current playback speed.</source>
         <translation>現在の再生速度を調整します。</translation>
     </message>
     <message>
-        <location filename="../source/widgets/playback/playbackwidget.ui" line="175"/>
+        <location filename="../source/widgets/playback/playbackwidget.ui" line="181"/>
         <source>Zoom:</source>
         <translation>ズーム:</translation>
     </message>
     <message>
-        <location filename="../source/widgets/playback/playbackwidget.ui" line="220"/>
+        <location filename="../source/widgets/playback/playbackwidget.ui" line="223"/>
         <source>System: 1, Staff: 1, Position: 1, String: 1</source>
         <translation>組段: 1, 譜表: 1, ポジション: 1, 弦: 1</translation>
     </message>
@@ -1950,1015 +1955,1024 @@
 <context>
     <name>PowerTabEditor</name>
     <message>
-        <location filename="../source/app/clipboard.cpp" line="129"/>
         <source>Cannot paste notes from a different tuning.</source>
-        <translation>別のチューニングの音符を貼り付けることはできません。</translation>
+        <translation type="vanished">別のチューニングの音符を貼り付けることはできません。</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="175"/>
+        <location filename="../source/app/powertabeditor.cpp" line="179"/>
         <source>Toolbox</source>
         <translation>ツールボックス</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="248"/>
+        <location filename="../source/app/powertabeditor.cpp" line="252"/>
         <source>Open</source>
         <translation>開く</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="278"/>
-        <location filename="../source/app/powertabeditor.cpp" line="303"/>
+        <location filename="../source/app/powertabeditor.cpp" line="282"/>
+        <location filename="../source/app/powertabeditor.cpp" line="307"/>
         <source>Error Opening File</source>
         <translation>ファイルオープンエラー</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="279"/>
-        <location filename="../source/app/powertabeditor.cpp" line="400"/>
+        <location filename="../source/app/powertabeditor.cpp" line="283"/>
+        <location filename="../source/app/powertabeditor.cpp" line="405"/>
         <source>Unsupported file type.</source>
         <translation>サポートされていないファイルタイプです。</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="304"/>
+        <location filename="../source/app/powertabeditor.cpp" line="308"/>
         <source>Error opening file: %1</source>
         <translation>ファイルオープンエラー: %1</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="337"/>
+        <location filename="../source/app/powertabeditor.cpp" line="342"/>
         <source>Close Document</source>
         <translation>ドキュメントを閉じる</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="338"/>
+        <location filename="../source/app/powertabeditor.cpp" line="343"/>
         <source>The document has been modified.</source>
         <translation>ドキュメントを修正しました。</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="339"/>
+        <location filename="../source/app/powertabeditor.cpp" line="344"/>
         <source>Do you want to save your changes?</source>
         <translation>変更内容を保存しますか？</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="399"/>
-        <location filename="../source/app/powertabeditor.cpp" line="414"/>
+        <location filename="../source/app/powertabeditor.cpp" line="404"/>
+        <location filename="../source/app/powertabeditor.cpp" line="419"/>
         <source>Error Saving File</source>
         <translation>ファイル保存エラー</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="415"/>
+        <location filename="../source/app/powertabeditor.cpp" line="420"/>
         <source>Error saving file: %1</source>
         <translation>ファイル保存エラー: %1</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="446"/>
+        <location filename="../source/app/powertabeditor.cpp" line="451"/>
         <source>Save As</source>
         <translation>名前を付けて保存</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="538"/>
+        <location filename="../source/app/powertabeditor.cpp" line="544"/>
         <source>Cut Notes</source>
         <translation>カットノート</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="554"/>
+        <location filename="../source/app/powertabeditor.cpp" line="560"/>
         <source>The clipboard does not contain any notes.</source>
         <translation>クリップボードに音符が含まれていません。</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="559"/>
+        <location filename="../source/app/powertabeditor.cpp" line="565"/>
         <source>Paste Notes</source>
         <translation>音符を貼り付け</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="604"/>
+        <location filename="../source/app/powertabeditor.cpp" line="618"/>
         <source>Midi Error</source>
         <translation>Midiエラー</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="626"/>
+        <location filename="../source/app/powertabeditor.cpp" line="640"/>
         <source>Pause</source>
         <translation>ポーズ</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="662"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2303"/>
+        <location filename="../source/app/powertabeditor.cpp" line="676"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2382"/>
         <source>Play</source>
         <translation>再生</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="885"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2466"/>
+        <location filename="../source/app/powertabeditor.cpp" line="899"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2545"/>
         <source>Remove Position</source>
         <translation>ポジションを削除</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="973"/>
+        <location filename="../source/app/powertabeditor.cpp" line="987"/>
         <source>Edit Chord Text</source>
         <translation>コードテキストを編集</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1010"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1024"/>
         <source>Edit Text Item</source>
         <translation>テキストアイテムを編集</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1058"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1072"/>
         <source>Edit Chord Diagram</source>
         <translation>コードダイアグラムを編集</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1156"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1170"/>
         <source>Edit Note Duration</source>
         <translation>音符の音価を編集</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1386"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1400"/>
         <source>Cannot add a multi-bar rest to a non-empty measure.</source>
         <translation>空でない小節に長休符を追加することはできません。</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1399"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1413"/>
         <source>Edit Multi-Bar Rest</source>
         <translation>長休符を編集</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1476"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1490"/>
         <source>Edit Tempo Marker</source>
         <translation>テンポマーカーを編集</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1515"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1529"/>
         <source>Edit Alteration of Pace</source>
         <translation>ペースの変更を編集</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1562"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1576"/>
         <source>Edit Musical Direction</source>
         <translation>反復記号を編集</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1600"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1614"/>
         <source>Edit Repeat Ending</source>
         <translation>繰り返し終了を編集</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1704"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1718"/>
         <source>Edit Volume Swell</source>
         <translation>ボリュームスウェルを編集</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1741"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1755"/>
         <source>Edit Tremolo Bar</source>
         <translation>トレモロバーを編集</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1841"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1855"/>
         <source>Edit Bend</source>
         <translation>ベンドを編集</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1965"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1979"/>
         <source>Edit Player Change</source>
         <translation>プレイヤーの変更を編集</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2192"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2264"/>
         <source>Untitled</source>
         <translation>名称未設定</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2205"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2277"/>
         <source>&amp;New</source>
         <translation>新規(&amp;N)</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2210"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2282"/>
         <source>&amp;Open...</source>
         <translation>開く(&amp;O)...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2215"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2287"/>
         <source>&amp;Close Tab</source>
         <translation>タブを閉じる(&amp;C)</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2220"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2292"/>
         <source>Save</source>
         <translation>保存</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2226"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2298"/>
         <source>Save As...</source>
         <translation>名前を付けて保存...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2232"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2304"/>
         <source>Print...</source>
         <translation>印刷...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2238"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2310"/>
         <source>Print Preview...</source>
         <translation>印刷プレビュー...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2242"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2315"/>
+        <source>Open Backup Folder...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../source/app/powertabeditor.cpp" line="2321"/>
         <source>Bulk Converter...</source>
         <translation>バルクコンバーター...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2248"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2327"/>
         <source>Customize Shortcuts...</source>
         <translation>ショートカットの設定...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2254"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2333"/>
         <source>&amp;Preferences...</source>
         <translation>環境設定(&amp;P)...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2260"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2339"/>
         <source>&amp;Quit</source>
         <translation>終了(&amp;Q)</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2265"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2344"/>
         <source>&amp;Undo</source>
         <translation>元に戻す(&amp;U)</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2268"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2347"/>
         <source>&amp;Redo</source>
         <translation>やり直し(&amp;R)</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2272"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2351"/>
         <source>Cut</source>
         <translation>切り取り</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2276"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2355"/>
         <source>Copy</source>
         <translation>コピー</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2281"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2360"/>
         <source>Paste</source>
         <translation>貼り付け</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2285"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2364"/>
         <source>Polish Score</source>
         <translation>スコアを整形</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2290"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2369"/>
         <source>Polish System</source>
         <translation>組段を整形</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2297"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2376"/>
         <source>File Information...</source>
         <translation>ファイル情報...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2315"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2394"/>
         <source>Play From Start Of Measure</source>
         <translation>小節の先頭から再生</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2322"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2401"/>
         <source>Stop</source>
         <translation>停止</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2326"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2405"/>
         <source>Rewind</source>
         <translation>巻き戻し</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2331"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2410"/>
         <source>Metronome</source>
         <translation>メトロノーム</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2337"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2416"/>
         <source>Count-In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2345"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2424"/>
         <source>First Section</source>
         <translation>最初のセクション</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2351"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2430"/>
         <source>Next Section</source>
         <translation>次のセクション</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2357"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2436"/>
         <source>Previous Section</source>
         <translation>前のセクション</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2363"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2442"/>
         <source>Last Section</source>
         <translation>最後のセクション</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2369"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2448"/>
         <source>Insert Space</source>
         <translation>スペースを挿入</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2375"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2454"/>
         <source>Remove Space</source>
         <translation>スペースを削除</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2391"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2470"/>
         <source>Move to &amp;Start</source>
         <translation>先頭へ移動(&amp;S)</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2397"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2476"/>
         <source>&amp;Next Position</source>
         <translation>次のポジション(&amp;N)</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2403"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2482"/>
         <source>&amp;Previous Position</source>
         <translation>前のポジション(&amp;P)</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2409"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2488"/>
         <source>Next String</source>
         <translation>次の弦</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2415"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2494"/>
         <source>Previous String</source>
         <translation>前の弦</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2421"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2500"/>
         <source>Move to &amp;End</source>
         <translation>末尾へ移動(&amp;E)</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2427"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2506"/>
         <source>Next Staff</source>
         <translation>次の譜表</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2433"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2512"/>
         <source>Previous Staff</source>
         <translation>前の譜表</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2438"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2517"/>
         <source>Next Bar</source>
         <translation>次の小節</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2444"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2523"/>
         <source>Previous Bar</source>
         <translation>前の小節</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2460"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2539"/>
         <source>Remove Selected Item</source>
         <translation>選択したアイテムの削除</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2471"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2550"/>
         <source>Go To Barline...</source>
         <translation>指定した小節へ移動...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2477"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2556"/>
         <source>Go To Rehearsal Sign...</source>
         <translation>リハーサルサインへ移動...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2484"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2563"/>
         <source>Chord Name...</source>
         <translation>コードネーム...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2490"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2569"/>
         <source>Text...</source>
         <translation>テキスト...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2498"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2577"/>
         <source>Add Chord Diagram...</source>
         <translation>コードダイアグラムを追加...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2503"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2582"/>
         <source>Insert System At End</source>
         <translation>末尾に組段を挿入</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2509"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2588"/>
         <source>Insert System Before</source>
         <translation>前に組段を挿入</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2516"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2595"/>
         <source>Insert System After</source>
         <translation>後に組段を挿入</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2523"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2602"/>
         <source>Remove Current System</source>
         <translation>現在の組段を削除</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2531"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2610"/>
         <source>Insert Staff Before</source>
         <translation>前に譜表を挿入</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2537"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2616"/>
         <source>Insert Staff After</source>
         <translation>後に譜表を挿入</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2543"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2622"/>
         <source>Remove Current Staff</source>
         <translation>現在の譜表を削除</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2548"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2627"/>
         <source>Increase</source>
         <translation>広げる</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2555"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2634"/>
         <source>Decrease</source>
         <translation>狭める</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2564"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2707"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2643"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2786"/>
         <source>Whole</source>
         <translation>全音</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2567"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2709"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2646"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2788"/>
         <source>Half</source>
         <translation>2分</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2570"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2711"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2649"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2790"/>
         <source>Quarter</source>
         <translation>4分</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2573"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2713"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2652"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2792"/>
         <source>8th</source>
         <translation>8分</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2576"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2715"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2655"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2794"/>
         <source>16th</source>
         <translation>16分</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2579"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2717"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2658"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2796"/>
         <source>32nd</source>
         <translation>32分</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2583"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2720"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2662"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2799"/>
         <source>64th</source>
         <translation>64分</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2588"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2667"/>
         <source>Increase Duration</source>
         <translation>音価を伸ばす</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2595"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2674"/>
         <source>Decrease Duration</source>
         <translation>音価を縮める</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2602"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2681"/>
         <source>Dotted</source>
         <translation>付点</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2606"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2685"/>
         <source>Double Dotted</source>
         <translation>複付点</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2611"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2690"/>
         <source>Add Dot</source>
         <translation>付点を追加</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2615"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2694"/>
         <source>Remove Dot</source>
         <translation>付点を削除</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2619"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2698"/>
         <source>Left Hand Fingering...</source>
         <translation>左手の運指...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2628"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2707"/>
         <source>Shift String Up</source>
         <translation>上の弦へシフト</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2634"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2713"/>
         <source>Shift String Down</source>
         <translation>下の弦へシフト</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2639"/>
-        <location filename="../source/app/powertabeditor.cpp" line="3933"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2718"/>
+        <location filename="../source/app/powertabeditor.cpp" line="4010"/>
         <source>Tied</source>
         <translation>タイ</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2644"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2723"/>
         <source>Muted</source>
         <translation>ミュート</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2647"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2726"/>
         <source>Ghost Note</source>
         <translation>ゴーストノート</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2651"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2730"/>
         <source>Fermata</source>
         <translation>フェルマータ</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2655"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2734"/>
         <source>Let Ring</source>
         <translation>レット・リング</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2659"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2738"/>
         <source>Grace Note</source>
         <translation>装飾音</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2664"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2743"/>
         <source>Staccato</source>
         <translation>スタッカート</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2668"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2747"/>
         <source>Accent</source>
         <translation>アクセント</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2672"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2751"/>
         <source>Heavy Accent</source>
         <translation>ヘビーアクセント</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2678"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2757"/>
         <source>8va</source>
         <translation>8va</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2681"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2760"/>
         <source>15ma</source>
         <translation>15ma</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2684"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2763"/>
         <source>8vb</source>
         <translation>8vb</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2687"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2766"/>
         <source>15mb</source>
         <translation>15mb</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2691"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2770"/>
         <source>Triplet</source>
         <translation>三連符</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2698"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2777"/>
         <source>Irregular Grouping</source>
         <translation>連符</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2724"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2803"/>
         <source>Add Rest</source>
         <translation>休符を追加</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2730"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2809"/>
         <source>Multi-Bar Rest...</source>
         <translation>長休符...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2738"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2817"/>
         <source>Rehearsal Sign...</source>
         <translation>リハーサルサイン...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2745"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2824"/>
         <source>Tempo Marker...</source>
         <translation>テンポマーカー...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2752"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2831"/>
         <source>Alteration of Pace...</source>
         <translation>ペースの変更...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2758"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2837"/>
         <source>Edit Key Signature...</source>
         <translation>調号を編集...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2765"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2844"/>
         <source>Edit Time Signature...</source>
         <translation>拍子記号を編集...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2772"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2851"/>
         <source>Insert Standard Barline</source>
         <translation>標準の小節線を挿入</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2779"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2858"/>
         <source>Barline...</source>
         <translation>小節線...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2785"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2864"/>
         <source>Musical Direction...</source>
         <translation>反復記号...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2793"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2872"/>
         <source>Repeat Ending...</source>
         <translation>繰り返し終了...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2801"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2880"/>
         <source>Dynamic...</source>
         <translation>ダイナミクス...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2808"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2811"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2814"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2817"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2820"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2823"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2826"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2829"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2887"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2890"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2893"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2896"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2899"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2902"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2905"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2908"/>
         <source>Dynamics</source>
         <translation>ダイナミクス</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2834"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2913"/>
         <source>Volume Swell...</source>
         <translation>ボリュームスウェル...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2841"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2920"/>
         <source>Hammer On/Pull Off</source>
         <translation>ハンマーオン/プルオフ</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2849"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2928"/>
         <source>Hammer On From Nowhere</source>
         <translation>どこからでもハンマーオン</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2854"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2933"/>
         <source>Pull Off To Nowhere</source>
         <translation>どこへでもプルオフ</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2858"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2937"/>
         <source>Natural Harmonic</source>
         <translation>ナチュラルハーモニクス</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2863"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2942"/>
         <source>Artificial Harmonic...</source>
         <translation>人口ハーモニクス...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2870"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2949"/>
         <source>Tapped Harmonic...</source>
         <translation>タッピングハーモニクス...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2879"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2958"/>
         <source>Bend...</source>
         <translation>ベンド...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2886"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2965"/>
         <source>Tremolo Bar...</source>
         <translation>トレモロバー...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2892"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2971"/>
         <source>Vibrato</source>
         <translation>ビブラート</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2897"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2976"/>
         <source>Wide Vibrato</source>
         <translation>ワイドビブラート</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2902"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2981"/>
         <source>Palm Mute</source>
         <translation>パームミュート</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2906"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2985"/>
         <source>Tremolo Picking</source>
         <translation>トレモロピッキング</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2910"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2989"/>
         <source>Arpeggio Up</source>
         <translation>アルペジオ・アップ</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2915"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2994"/>
         <source>Arpeggio Down</source>
         <translation>アルペジオ・ダウン</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2920"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2999"/>
         <source>Tap</source>
         <translation>タッピング</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2924"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3003"/>
         <source>Trill...</source>
         <translation>トリル...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2930"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3009"/>
         <source>Pickstroke Up</source>
         <translation>アップピッキング</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2935"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3014"/>
         <source>Pickstroke Down</source>
         <translation>ダウンピッキング</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2941"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3020"/>
         <source>Slide Into From Above</source>
         <translation>上からスライドイン</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2946"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3025"/>
         <source>Slide Into From Below</source>
         <translation>下からスライドイン</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2951"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3030"/>
         <source>Shift Slide</source>
         <translation>シフトスライド</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2955"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3034"/>
         <source>Legato Slide</source>
         <translation>レガートスライド</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2961"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3040"/>
         <source>Slide Out Of Downwards</source>
         <translation>下へスライドアウト</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2966"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3045"/>
         <source>Slide Out Of Upwards</source>
         <translation>上へスライドアウト</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2973"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3052"/>
         <source>Add Player</source>
         <translation>プレイヤー追加</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2978"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3057"/>
         <source>Add Instrument</source>
         <translation>楽器を追加</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2982"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3061"/>
         <source>Player Change...</source>
         <translation>プレイヤーの変更...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2989"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3068"/>
         <source>Tuning Dictionary...</source>
         <translation>チューニング辞書...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2996"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3075"/>
         <source>Edit View Filters...</source>
         <translation>ビューフィルタを編集...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3013"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3092"/>
         <source>Next Tab</source>
         <translation>次のタブ</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3019"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3098"/>
         <source>Previous Tab</source>
         <translation>前のタブ</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3033"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3112"/>
         <source>Zoom In</source>
         <translation>ズームイン</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3038"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3117"/>
         <source>Zoom Out</source>
         <translation>ズームアウト</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3044"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3123"/>
         <source>Report Bug...</source>
         <translation>バグを報告する...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3050"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3129"/>
         <source>Translate This Application...</source>
         <translation>このアプリケーションを翻訳する...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3056"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3135"/>
         <source>Application Info...</source>
         <translation>アプリケーション情報...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3100"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3179"/>
         <source>Mixer</source>
         <translation>ミキサー</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3125"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3204"/>
         <source>Instruments</source>
         <translation>楽器</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3228"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3307"/>
         <source>&amp;File</source>
         <translation>ファイル(&amp;F)</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3239"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3318"/>
         <source>Recent Files</source>
         <translation>最近使用したファイル</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3249"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3329"/>
         <source>&amp;Edit</source>
         <translation>編集(&amp;E)</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3265"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3345"/>
         <source>Play&amp;back</source>
         <translation>再生(&amp;B)</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3274"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3354"/>
         <source>&amp;Position</source>
         <translation>ポジション(&amp;P)</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3275"/>
-        <location filename="../source/app/powertabeditor.cpp" line="3311"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3355"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3391"/>
         <source>&amp;Section</source>
         <translation>セクション(&amp;S)</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3281"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3361"/>
         <source>&amp;Staff</source>
         <translation>譜表(&amp;S)</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3304"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3384"/>
         <source>&amp;Text</source>
         <translation>テキスト(&amp;T)</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3321"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3401"/>
         <source>&amp;Line Spacing</source>
         <translation>行間(&amp;L)</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3326"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3406"/>
         <source>&amp;Notes</source>
         <translation>音符(&amp;N)</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3360"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3440"/>
         <source>Octave</source>
         <translation>オクターブ</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3370"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3450"/>
         <source>Rests</source>
         <translation>休符</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3383"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3463"/>
         <source>&amp;Music Symbols</source>
         <translation>音楽記号(&amp;M)</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3397"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3477"/>
         <source>&amp;Tab Symbols</source>
         <translation>タブ記号(&amp;T)</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3398"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3478"/>
         <source>&amp;Hammer Ons/Pull Offs</source>
         <translation>&amp;ハンマーオン/プルオフ</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3412"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3492"/>
         <source>Slide Into</source>
         <translation>スライドイン</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3419"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3499"/>
         <source>Slide Out Of</source>
         <translation>スライドアウト</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3439"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3519"/>
         <source>&amp;Player</source>
         <translation>プレイヤー(&amp;P)</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3448"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3528"/>
         <source>&amp;Window</source>
         <translation>ウィンドウ(&amp;W)</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3459"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3539"/>
         <source>&amp;Help</source>
         <translation>ヘルプ(&amp;H)</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3939"/>
+        <location filename="../source/app/powertabeditor.cpp" line="4016"/>
         <source>Insert Tied Note</source>
         <translation>タイ付き音符を挿入</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="4034"/>
+        <location filename="../source/app/powertabeditor.cpp" line="4111"/>
         <source>Edit Barline</source>
         <translation>小節線を編集</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="4039"/>
+        <location filename="../source/app/powertabeditor.cpp" line="4116"/>
         <source>Insert Barline</source>
         <translation>小節線を挿入</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="4045"/>
+        <location filename="../source/app/powertabeditor.cpp" line="4122"/>
         <source>Barline</source>
         <translation>小節線</translation>
     </message>
     <message>
-        <location filename="../source/build/main.cpp" line="201"/>
+        <location filename="../source/build/main.cpp" line="191"/>
         <source>A guitar tablature editor.</source>
         <translation>ギタータブ譜エディタ。</translation>
     </message>
     <message>
-        <location filename="../source/build/main.cpp" line="207"/>
+        <location filename="../source/build/main.cpp" line="197"/>
         <source>The files to be opened</source>
         <translation>開くファイル</translation>
+    </message>
+    <message>
+        <location filename="../source/app/clipboard.cpp" line="130"/>
+        <source>Cannot paste notes from a different number of strings.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2994,9 +3008,13 @@
         <translation>ワイドビブラートの強さ:</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/preferencesdialog.ui" line="86"/>
         <source>Play Notes While Editing</source>
-        <translation>編集中にノートを再生する</translation>
+        <translation type="vanished">編集中にノートを再生する</translation>
+    </message>
+    <message>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="86"/>
+        <source>Play Notes While Editing:</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../source/dialogs/preferencesdialog.ui" line="101"/>
@@ -3012,7 +3030,7 @@
     <message>
         <location filename="../source/dialogs/preferencesdialog.ui" line="122"/>
         <location filename="../source/dialogs/preferencesdialog.ui" line="193"/>
-        <location filename="../source/dialogs/preferencesdialog.ui" line="322"/>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="355"/>
         <source>Preset:</source>
         <translation>プリセット:</translation>
     </message>
@@ -3077,27 +3095,42 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/preferencesdialog.ui" line="297"/>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="296"/>
+        <source>Backup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="304"/>
+        <source>Enable Auto Backup:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="314"/>
+        <source>Backup Interval (seconds):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="330"/>
         <source>Default Instrument</source>
         <translation>デフォルトの楽器</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/preferencesdialog.ui" line="312"/>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="345"/>
         <source>Name:</source>
         <translation>名前:</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/preferencesdialog.ui" line="332"/>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="365"/>
         <source>Tuning:</source>
         <translation>チューニング:</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/preferencesdialog.ui" line="339"/>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="372"/>
         <source>Tuning</source>
         <translation>チューニング</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/preferencesdialog.cpp" line="146"/>
+        <location filename="../source/dialogs/preferencesdialog.cpp" line="148"/>
         <source>Click to adjust tuning.</source>
         <translation>クリックでチューニングを調整できます。</translation>
     </message>
@@ -3257,7 +3290,7 @@
         <translation>ポジションを削除</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1355"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1369"/>
         <source>Remove Multi-Bar Rest</source>
         <translation>長休符を削除</translation>
     </message>
@@ -3370,67 +3403,67 @@
         <translation>ダブルクリックでスコア情報を編集できます。</translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="155"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="150"/>
         <source>Double-click to change clef type.</source>
         <translation>ダブルクリックで音部記号の種類を変更できます。</translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="197"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="192"/>
         <source>Double-click to edit the number of strings.</source>
         <translation>ダブルクリックで弦の数を編集できます。</translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="304"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="298"/>
         <source>Double-click to edit rehearsal sign.</source>
         <translation>ダブルクリックでリハーサルサインを編集できます。</translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="507"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="500"/>
         <source>Double-click to edit repeat endings.</source>
         <translation>ダブルクリックで繰り返し終了を編集できます。</translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="638"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="634"/>
         <source>Double-click to edit tempo marker.</source>
         <translation>ダブルクリックでテンポマーカーを編集できます。</translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="745"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="741"/>
         <source>Double-click to edit chord text.</source>
         <translation>ダブルクリックでコードテキストを編集できます。</translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="771"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="767"/>
         <source>Double-click to edit text.</source>
         <translation>ダブルクリックでテキストを編集できます。</translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="941"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="937"/>
         <source>Double-click to edit the active players.</source>
         <translation>ダブルクリックでアクティブなプレーヤーを編集できます。</translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="1394"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="1389"/>
         <source>Double-click to edit volume swell.</source>
         <translation>ダブルクリックでボリュームスウェルを編集できます。</translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="1414"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="1409"/>
         <source>Double-click to edit tremolo bar.</source>
         <translation>ダブルクリックでトレモロバーを編集できます。</translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="1589"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="1583"/>
         <source>Double-click to edit dynamic.</source>
         <translation>ダブルクリックでダイナミクスを編集できます。</translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="1932"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="1926"/>
         <source>Double-click to edit multi-bar rest.</source>
         <translation>ダブルクリックで長休符を編集できます。</translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="2185"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="2178"/>
         <source>Double-click to edit bend.</source>
         <translation>ダブルクリックでベンドを編集できます。</translation>
     </message>

--- a/translations/powertabeditor_ru.ts
+++ b/translations/powertabeditor_ru.ts
@@ -547,12 +547,12 @@
         <translation type="vanished">Исходная папка</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/bulkconverterdialog.cpp" line="172"/>
+        <location filename="../source/dialogs/bulkconverterdialog.cpp" line="170"/>
         <source>Convert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/bulkconverterdialog.cpp" line="190"/>
+        <location filename="../source/dialogs/bulkconverterdialog.cpp" line="188"/>
         <source>Directory To Convert</source>
         <translation>Папка для конвертирования</translation>
     </message>
@@ -598,7 +598,7 @@
         <translation>Диаграмма:</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chorddiagramdialog.cpp" line="48"/>
+        <location filename="../source/dialogs/chorddiagramdialog.cpp" line="47"/>
         <source>Click to edit chord name.</source>
         <translation>Нажмите, чтобы изменить название аккорда.</translation>
     </message>
@@ -626,79 +626,84 @@
         <translation>Без аккорда</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="95"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="702"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="94"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="694"/>
         <source>C</source>
         <translation>До</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="115"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="722"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="113"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="713"/>
         <source>D</source>
         <translation>Ре</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="135"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="742"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="132"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="732"/>
         <source>E</source>
         <translation>Ми</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="155"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="762"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="151"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="751"/>
         <source>F</source>
         <translation>Фа</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="175"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="782"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="170"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="770"/>
         <source>G</source>
         <translation>Соль</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="195"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="802"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="189"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="789"/>
         <source>A</source>
         <translation>Ля</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="215"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="822"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="208"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="808"/>
         <source>B</source>
         <translation>Си</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="300"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="293"/>
         <source>Brackets</source>
         <translation>Скобки</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="309"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="302"/>
         <source>Formula:</source>
         <translation>Формула:</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="316"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="309"/>
         <source>Additions:</source>
         <translation>Дополнения:</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="323"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="316"/>
         <source>Extensions:</source>
         <translation>Расширения:</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="330"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="323"/>
         <source>Alterations:</source>
         <translation>Алтерации:</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="337"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="330"/>
         <source>Bass Note:</source>
         <translation>Басовая нота:</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="911"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="892"/>
+        <source>Custom Label</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="907"/>
         <source>Chords in Score:</source>
         <translation>Аккорды в партитуре:</translation>
     </message>
@@ -1610,7 +1615,7 @@
     <message>
         <location filename="../source/widgets/mixer/mixeritem.ui" line="72"/>
         <source>Player Name</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Имя исполнителя</translation>
     </message>
     <message>
         <location filename="../source/widgets/mixer/mixeritem.ui" line="107"/>
@@ -1839,7 +1844,7 @@
     <message>
         <location filename="../source/widgets/playback/playbackwidget.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Форма</translation>
     </message>
     <message>
         <location filename="../source/widgets/playback/playbackwidget.ui" line="49"/>
@@ -1862,17 +1867,17 @@
         <translation>Скорость:</translation>
     </message>
     <message>
-        <location filename="../source/widgets/playback/playbackwidget.ui" line="103"/>
+        <location filename="../source/widgets/playback/playbackwidget.ui" line="109"/>
         <source>Adjusts the current playback speed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/widgets/playback/playbackwidget.ui" line="175"/>
+        <location filename="../source/widgets/playback/playbackwidget.ui" line="181"/>
         <source>Zoom:</source>
         <translation>Масштаб:</translation>
     </message>
     <message>
-        <location filename="../source/widgets/playback/playbackwidget.ui" line="220"/>
+        <location filename="../source/widgets/playback/playbackwidget.ui" line="223"/>
         <source>System: 1, Staff: 1, Position: 1, String: 1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1949,1014 +1954,1019 @@
 <context>
     <name>PowerTabEditor</name>
     <message>
-        <location filename="../source/app/clipboard.cpp" line="129"/>
-        <source>Cannot paste notes from a different tuning.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../source/app/powertabeditor.cpp" line="175"/>
+        <location filename="../source/app/powertabeditor.cpp" line="179"/>
         <source>Toolbox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="248"/>
+        <location filename="../source/app/powertabeditor.cpp" line="252"/>
         <source>Open</source>
         <translation>Открыть</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="278"/>
-        <location filename="../source/app/powertabeditor.cpp" line="303"/>
+        <location filename="../source/app/powertabeditor.cpp" line="282"/>
+        <location filename="../source/app/powertabeditor.cpp" line="307"/>
         <source>Error Opening File</source>
         <translation>Ошибка открытия файла</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="279"/>
-        <location filename="../source/app/powertabeditor.cpp" line="400"/>
+        <location filename="../source/app/powertabeditor.cpp" line="283"/>
+        <location filename="../source/app/powertabeditor.cpp" line="405"/>
         <source>Unsupported file type.</source>
         <translation>Неподдерживаемый тип файла.</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="304"/>
+        <location filename="../source/app/powertabeditor.cpp" line="308"/>
         <source>Error opening file: %1</source>
         <translation>Ошибка открытия файла: %1</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="337"/>
+        <location filename="../source/app/powertabeditor.cpp" line="342"/>
         <source>Close Document</source>
         <translation>Закрыть документ</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="338"/>
+        <location filename="../source/app/powertabeditor.cpp" line="343"/>
         <source>The document has been modified.</source>
         <translation>Документ был изменён.</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="339"/>
+        <location filename="../source/app/powertabeditor.cpp" line="344"/>
         <source>Do you want to save your changes?</source>
         <translation>Вы хотите сохранить изменения?</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="399"/>
-        <location filename="../source/app/powertabeditor.cpp" line="414"/>
+        <location filename="../source/app/powertabeditor.cpp" line="404"/>
+        <location filename="../source/app/powertabeditor.cpp" line="419"/>
         <source>Error Saving File</source>
         <translation>Ошибка сохранения файла</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="415"/>
+        <location filename="../source/app/powertabeditor.cpp" line="420"/>
         <source>Error saving file: %1</source>
         <translation>Ошибка сохранения файла: %1</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="446"/>
+        <location filename="../source/app/powertabeditor.cpp" line="451"/>
         <source>Save As</source>
         <translation>Сохранить как</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="538"/>
+        <location filename="../source/app/powertabeditor.cpp" line="544"/>
         <source>Cut Notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="554"/>
+        <location filename="../source/app/powertabeditor.cpp" line="560"/>
         <source>The clipboard does not contain any notes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="559"/>
+        <location filename="../source/app/powertabeditor.cpp" line="565"/>
         <source>Paste Notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="604"/>
+        <location filename="../source/app/powertabeditor.cpp" line="618"/>
         <source>Midi Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="626"/>
+        <location filename="../source/app/powertabeditor.cpp" line="640"/>
         <source>Pause</source>
         <translation>Пауза</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="662"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2303"/>
+        <location filename="../source/app/powertabeditor.cpp" line="676"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2382"/>
         <source>Play</source>
         <translation>Воспроизвести</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="885"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2466"/>
+        <location filename="../source/app/powertabeditor.cpp" line="899"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2545"/>
         <source>Remove Position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="973"/>
+        <location filename="../source/app/powertabeditor.cpp" line="987"/>
         <source>Edit Chord Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1010"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1024"/>
         <source>Edit Text Item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1058"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1072"/>
         <source>Edit Chord Diagram</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1156"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1170"/>
         <source>Edit Note Duration</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Редактировать длительность ноты</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1386"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1400"/>
         <source>Cannot add a multi-bar rest to a non-empty measure.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1399"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1413"/>
         <source>Edit Multi-Bar Rest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1476"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1490"/>
         <source>Edit Tempo Marker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1515"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1529"/>
         <source>Edit Alteration of Pace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1562"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1576"/>
         <source>Edit Musical Direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1600"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1614"/>
         <source>Edit Repeat Ending</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1704"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1718"/>
         <source>Edit Volume Swell</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1741"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1755"/>
         <source>Edit Tremolo Bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1841"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1855"/>
         <source>Edit Bend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1965"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1979"/>
         <source>Edit Player Change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2192"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2264"/>
         <source>Untitled</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Без названия</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2205"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2277"/>
         <source>&amp;New</source>
         <translation>&amp;Новый</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2210"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2282"/>
         <source>&amp;Open...</source>
         <translation>&amp;Открыть...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2215"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2287"/>
         <source>&amp;Close Tab</source>
         <translation>&amp;Закрыть вкладку</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2220"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2292"/>
         <source>Save</source>
         <translation>Сохранить</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2226"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2298"/>
         <source>Save As...</source>
         <translation>Сохранить как...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2232"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2304"/>
         <source>Print...</source>
         <translation>Печать...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2238"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2310"/>
         <source>Print Preview...</source>
         <translation>Предпросмотр печати...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2242"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2315"/>
+        <source>Open Backup Folder...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../source/app/powertabeditor.cpp" line="2321"/>
         <source>Bulk Converter...</source>
         <translation>Массовое конвертирование...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2248"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2327"/>
         <source>Customize Shortcuts...</source>
         <translation>Настроить комбинации клавиш...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2254"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2333"/>
         <source>&amp;Preferences...</source>
         <translation>Н&amp;астройки...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2260"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2339"/>
         <source>&amp;Quit</source>
         <translation>&amp;Выход</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2265"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2344"/>
         <source>&amp;Undo</source>
         <translation>О&amp;тменить</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2268"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2347"/>
         <source>&amp;Redo</source>
         <translation>&amp;Повторить</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2272"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2351"/>
         <source>Cut</source>
         <translation>Вырезать</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2276"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2355"/>
         <source>Copy</source>
         <translation>Копировать</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2281"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2360"/>
         <source>Paste</source>
         <translation>Вставить</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2285"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2364"/>
         <source>Polish Score</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2290"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2369"/>
         <source>Polish System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2297"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2376"/>
         <source>File Information...</source>
         <translation>Информация о файле...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2315"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2394"/>
         <source>Play From Start Of Measure</source>
         <translation>Воспр. с начала отрывка</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2322"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2401"/>
         <source>Stop</source>
         <translation>Стоп</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2326"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2405"/>
         <source>Rewind</source>
         <translation>Перемотка назад</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2331"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2410"/>
         <source>Metronome</source>
         <translation>Метроном</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2337"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2416"/>
         <source>Count-In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2345"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2424"/>
         <source>First Section</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2351"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2430"/>
         <source>Next Section</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2357"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2436"/>
         <source>Previous Section</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2363"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2442"/>
         <source>Last Section</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2369"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2448"/>
         <source>Insert Space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2375"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2454"/>
         <source>Remove Space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2391"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2470"/>
         <source>Move to &amp;Start</source>
         <translation>Перейти к &amp;началу</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2397"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2476"/>
         <source>&amp;Next Position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2403"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2482"/>
         <source>&amp;Previous Position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2409"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2488"/>
         <source>Next String</source>
         <translation>Следующая струна</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2415"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2494"/>
         <source>Previous String</source>
         <translation>Предыдущая струна</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2421"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2500"/>
         <source>Move to &amp;End</source>
         <translation>Переместить в &amp;конец</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2427"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2506"/>
         <source>Next Staff</source>
         <translation>Следующий нотоносец</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2433"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2512"/>
         <source>Previous Staff</source>
         <translation>Предыдущий нотоносец</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2438"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2517"/>
         <source>Next Bar</source>
         <translation>Следующий такт</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2444"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2523"/>
         <source>Previous Bar</source>
         <translation>Предыдущий такт</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2460"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2539"/>
         <source>Remove Selected Item</source>
         <translation>Удалить выбранный элемент</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2471"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2550"/>
         <source>Go To Barline...</source>
         <translation>Перейти к такту…</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2477"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2556"/>
         <source>Go To Rehearsal Sign...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2484"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2563"/>
         <source>Chord Name...</source>
         <translation>Название аккорда...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2490"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2569"/>
         <source>Text...</source>
         <translation>Текст...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2498"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2577"/>
         <source>Add Chord Diagram...</source>
         <translation>Добавить диаграмму аккорда...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2503"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2582"/>
         <source>Insert System At End</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2509"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2588"/>
         <source>Insert System Before</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2516"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2595"/>
         <source>Insert System After</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2523"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2602"/>
         <source>Remove Current System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2531"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2610"/>
         <source>Insert Staff Before</source>
         <translation>Вставить нотоносец перед</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2537"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2616"/>
         <source>Insert Staff After</source>
         <translation>Вставить нотоносец после</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2543"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2622"/>
         <source>Remove Current Staff</source>
         <translation>Удалить текущий нотоносец</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2548"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2627"/>
         <source>Increase</source>
         <translation>Увеличить</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2555"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2634"/>
         <source>Decrease</source>
         <translation>Уменьшить</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2564"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2707"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2643"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2786"/>
         <source>Whole</source>
         <translation>Целая</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2567"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2709"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2646"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2788"/>
         <source>Half</source>
         <translation>Половинная</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2570"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2711"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2649"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2790"/>
         <source>Quarter</source>
         <translation>Четвертная</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2573"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2713"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2652"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2792"/>
         <source>8th</source>
         <translation>Восьмая</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2576"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2715"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2655"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2794"/>
         <source>16th</source>
         <translation>16-я</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2579"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2717"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2658"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2796"/>
         <source>32nd</source>
         <translation>32-я</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2583"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2720"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2662"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2799"/>
         <source>64th</source>
         <translation>64-я</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2588"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2667"/>
         <source>Increase Duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2595"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2674"/>
         <source>Decrease Duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2602"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2681"/>
         <source>Dotted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2606"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2685"/>
         <source>Double Dotted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2611"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2690"/>
         <source>Add Dot</source>
         <translation>Добавить точку</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2615"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2694"/>
         <source>Remove Dot</source>
         <translation>Убрать точку</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2619"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2698"/>
         <source>Left Hand Fingering...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2628"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2707"/>
         <source>Shift String Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2634"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2713"/>
         <source>Shift String Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2639"/>
-        <location filename="../source/app/powertabeditor.cpp" line="3933"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2718"/>
+        <location filename="../source/app/powertabeditor.cpp" line="4010"/>
         <source>Tied</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2644"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2723"/>
         <source>Muted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2647"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2726"/>
         <source>Ghost Note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2651"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2730"/>
         <source>Fermata</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Фермата</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2655"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2734"/>
         <source>Let Ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2659"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2738"/>
         <source>Grace Note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2664"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2743"/>
         <source>Staccato</source>
         <translation>Стаккато</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2668"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2747"/>
         <source>Accent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2672"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2751"/>
         <source>Heavy Accent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2678"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2757"/>
         <source>8va</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2681"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2760"/>
         <source>15ma</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2684"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2763"/>
         <source>8vb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2687"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2766"/>
         <source>15mb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2691"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2770"/>
         <source>Triplet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2698"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2777"/>
         <source>Irregular Grouping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2724"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2803"/>
         <source>Add Rest</source>
         <translation>Добавить паузу</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2730"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2809"/>
         <source>Multi-Bar Rest...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2738"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2817"/>
         <source>Rehearsal Sign...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2745"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2824"/>
         <source>Tempo Marker...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2752"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2831"/>
         <source>Alteration of Pace...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2758"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2837"/>
         <source>Edit Key Signature...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2765"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2844"/>
         <source>Edit Time Signature...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2772"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2851"/>
         <source>Insert Standard Barline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2779"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2858"/>
         <source>Barline...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2785"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2864"/>
         <source>Musical Direction...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2793"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2872"/>
         <source>Repeat Ending...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2801"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2880"/>
         <source>Dynamic...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2808"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2811"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2814"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2817"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2820"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2823"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2826"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2829"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2887"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2890"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2893"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2896"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2899"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2902"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2905"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2908"/>
         <source>Dynamics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2834"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2913"/>
         <source>Volume Swell...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2841"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2920"/>
         <source>Hammer On/Pull Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2849"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2928"/>
         <source>Hammer On From Nowhere</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2854"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2933"/>
         <source>Pull Off To Nowhere</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2858"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2937"/>
         <source>Natural Harmonic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2863"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2942"/>
         <source>Artificial Harmonic...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2870"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2949"/>
         <source>Tapped Harmonic...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2879"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2958"/>
         <source>Bend...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2886"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2965"/>
         <source>Tremolo Bar...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2892"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2971"/>
         <source>Vibrato</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2897"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2976"/>
         <source>Wide Vibrato</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2902"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2981"/>
         <source>Palm Mute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2906"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2985"/>
         <source>Tremolo Picking</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2910"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2989"/>
         <source>Arpeggio Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2915"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2994"/>
         <source>Arpeggio Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2920"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2999"/>
         <source>Tap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2924"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3003"/>
         <source>Trill...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2930"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3009"/>
         <source>Pickstroke Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2935"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3014"/>
         <source>Pickstroke Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2941"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3020"/>
         <source>Slide Into From Above</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2946"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3025"/>
         <source>Slide Into From Below</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2951"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3030"/>
         <source>Shift Slide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2955"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3034"/>
         <source>Legato Slide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2961"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3040"/>
         <source>Slide Out Of Downwards</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2966"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3045"/>
         <source>Slide Out Of Upwards</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2973"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3052"/>
         <source>Add Player</source>
         <translation>Добавить исполнителя</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2978"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3057"/>
         <source>Add Instrument</source>
         <translation>Добавить инструмент</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2982"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3061"/>
         <source>Player Change...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2989"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3068"/>
         <source>Tuning Dictionary...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2996"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3075"/>
         <source>Edit View Filters...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3013"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3092"/>
         <source>Next Tab</source>
         <translation>Следующая вкладка</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3019"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3098"/>
         <source>Previous Tab</source>
         <translation>Предыдущая вкладка</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3033"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3112"/>
         <source>Zoom In</source>
         <translation>Увеличить</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3038"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3117"/>
         <source>Zoom Out</source>
         <translation>Уменьшить</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3044"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3123"/>
         <source>Report Bug...</source>
         <translation>Сообщить об ошибке...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3050"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3129"/>
         <source>Translate This Application...</source>
         <translation>Перевести это приложение...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3056"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3135"/>
         <source>Application Info...</source>
         <translation>О программе...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3100"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3179"/>
         <source>Mixer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3125"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3204"/>
         <source>Instruments</source>
         <translation>Музыкальные инструменты</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3228"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3307"/>
         <source>&amp;File</source>
         <translation>&amp;Файл</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3239"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3318"/>
         <source>Recent Files</source>
         <translation>Последние файлы</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3249"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3329"/>
         <source>&amp;Edit</source>
         <translation>&amp;Правка</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3265"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3345"/>
         <source>Play&amp;back</source>
         <translation>&amp;Воспроизведение</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3274"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3354"/>
         <source>&amp;Position</source>
         <translation>По&amp;зиция</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3275"/>
-        <location filename="../source/app/powertabeditor.cpp" line="3311"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3355"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3391"/>
         <source>&amp;Section</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3281"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3361"/>
         <source>&amp;Staff</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3304"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3384"/>
         <source>&amp;Text</source>
         <translation>&amp;Текст</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3321"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3401"/>
         <source>&amp;Line Spacing</source>
         <translation>&amp;Межлинейный промежуток</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3326"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3406"/>
         <source>&amp;Notes</source>
         <translation>&amp;Ноты</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3360"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3440"/>
         <source>Octave</source>
         <translation>Октава</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3370"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3450"/>
         <source>Rests</source>
         <translation>Па&amp;узы</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3383"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3463"/>
         <source>&amp;Music Symbols</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3397"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3477"/>
         <source>&amp;Tab Symbols</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3398"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3478"/>
         <source>&amp;Hammer Ons/Pull Offs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3412"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3492"/>
         <source>Slide Into</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3419"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3499"/>
         <source>Slide Out Of</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3439"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3519"/>
         <source>&amp;Player</source>
         <translation>&amp;Исполнитель</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3448"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3528"/>
         <source>&amp;Window</source>
         <translation>&amp;Окно</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3459"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3539"/>
         <source>&amp;Help</source>
         <translation>&amp;Справка</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3939"/>
+        <location filename="../source/app/powertabeditor.cpp" line="4016"/>
         <source>Insert Tied Note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="4034"/>
+        <location filename="../source/app/powertabeditor.cpp" line="4111"/>
         <source>Edit Barline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="4039"/>
+        <location filename="../source/app/powertabeditor.cpp" line="4116"/>
         <source>Insert Barline</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Вставить разделительную черту</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="4045"/>
+        <location filename="../source/app/powertabeditor.cpp" line="4122"/>
         <source>Barline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/build/main.cpp" line="201"/>
+        <location filename="../source/build/main.cpp" line="191"/>
         <source>A guitar tablature editor.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/build/main.cpp" line="207"/>
+        <location filename="../source/build/main.cpp" line="197"/>
         <source>The files to be opened</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../source/app/clipboard.cpp" line="130"/>
+        <source>Cannot paste notes from a different number of strings.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2993,9 +3003,13 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/preferencesdialog.ui" line="86"/>
         <source>Play Notes While Editing</source>
-        <translation>Проигрывать ноты при редактировании</translation>
+        <translation type="vanished">Проигрывать ноты при редактировании</translation>
+    </message>
+    <message>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="86"/>
+        <source>Play Notes While Editing:</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../source/dialogs/preferencesdialog.ui" line="101"/>
@@ -3011,7 +3025,7 @@
     <message>
         <location filename="../source/dialogs/preferencesdialog.ui" line="122"/>
         <location filename="../source/dialogs/preferencesdialog.ui" line="193"/>
-        <location filename="../source/dialogs/preferencesdialog.ui" line="322"/>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="355"/>
         <source>Preset:</source>
         <translation>Выбрать:</translation>
     </message>
@@ -3076,27 +3090,42 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/preferencesdialog.ui" line="297"/>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="296"/>
+        <source>Backup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="304"/>
+        <source>Enable Auto Backup:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="314"/>
+        <source>Backup Interval (seconds):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="330"/>
         <source>Default Instrument</source>
         <translation>Инструмент по умолчанию</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/preferencesdialog.ui" line="312"/>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="345"/>
         <source>Name:</source>
         <translation type="unfinished">Название:</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/preferencesdialog.ui" line="332"/>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="365"/>
         <source>Tuning:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/preferencesdialog.ui" line="339"/>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="372"/>
         <source>Tuning</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Строй</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/preferencesdialog.cpp" line="146"/>
+        <location filename="../source/dialogs/preferencesdialog.cpp" line="148"/>
         <source>Click to adjust tuning.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3256,7 +3285,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1355"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1369"/>
         <source>Remove Multi-Bar Rest</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3369,67 +3398,67 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="155"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="150"/>
         <source>Double-click to change clef type.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="197"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="192"/>
         <source>Double-click to edit the number of strings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="304"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="298"/>
         <source>Double-click to edit rehearsal sign.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="507"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="500"/>
         <source>Double-click to edit repeat endings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="638"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="634"/>
         <source>Double-click to edit tempo marker.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="745"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="741"/>
         <source>Double-click to edit chord text.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="771"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="767"/>
         <source>Double-click to edit text.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="941"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="937"/>
         <source>Double-click to edit the active players.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="1394"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="1389"/>
         <source>Double-click to edit volume swell.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="1414"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="1409"/>
         <source>Double-click to edit tremolo bar.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="1589"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="1583"/>
         <source>Double-click to edit dynamic.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="1932"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="1926"/>
         <source>Double-click to edit multi-bar rest.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="2185"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="2178"/>
         <source>Double-click to edit bend.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3720,7 +3749,7 @@
     <message>
         <location filename="../source/widgets/toolbox/toolbox.ui" line="20"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Форма</translation>
     </message>
     <message>
         <location filename="../source/widgets/toolbox/toolbox.ui" line="161"/>
@@ -3825,7 +3854,7 @@
     <message>
         <location filename="../source/dialogs/tuningdialog.ui" line="17"/>
         <source>Tuning</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Строй</translation>
     </message>
     <message>
         <location filename="../source/dialogs/tuningdialog.ui" line="31"/>

--- a/translations/powertabeditor_tr.ts
+++ b/translations/powertabeditor_tr.ts
@@ -547,12 +547,12 @@
         <translation type="vanished">Kaynak Dizini</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/bulkconverterdialog.cpp" line="172"/>
+        <location filename="../source/dialogs/bulkconverterdialog.cpp" line="170"/>
         <source>Convert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/bulkconverterdialog.cpp" line="190"/>
+        <location filename="../source/dialogs/bulkconverterdialog.cpp" line="188"/>
         <source>Directory To Convert</source>
         <translation>Dönüştürülecek Dizin</translation>
     </message>
@@ -598,7 +598,7 @@
         <translation>Diyagram:</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chorddiagramdialog.cpp" line="48"/>
+        <location filename="../source/dialogs/chorddiagramdialog.cpp" line="47"/>
         <source>Click to edit chord name.</source>
         <translation>Akor adını değiştirmek için tıkla.</translation>
     </message>
@@ -626,79 +626,84 @@
         <translation>Akor Yok</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="95"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="702"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="94"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="694"/>
         <source>C</source>
         <translation>Do</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="115"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="722"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="113"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="713"/>
         <source>D</source>
         <translation>Re</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="135"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="742"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="132"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="732"/>
         <source>E</source>
         <translation>Mi</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="155"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="762"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="151"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="751"/>
         <source>F</source>
         <translation>Fa</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="175"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="782"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="170"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="770"/>
         <source>G</source>
         <translation>Sol</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="195"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="802"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="189"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="789"/>
         <source>A</source>
         <translation>La</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="215"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="822"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="208"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="808"/>
         <source>B</source>
         <translation>Si</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="300"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="293"/>
         <source>Brackets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="309"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="302"/>
         <source>Formula:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="316"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="309"/>
         <source>Additions:</source>
         <translation>Eklemeler:</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="323"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="316"/>
         <source>Extensions:</source>
         <translation type="unfinished">Uzatmalar:</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="330"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="323"/>
         <source>Alterations:</source>
         <translation type="unfinished">Değiştirmeler:</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="337"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="330"/>
         <source>Bass Note:</source>
         <translation>Bas Nota:</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="911"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="892"/>
+        <source>Custom Label</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="907"/>
         <source>Chords in Score:</source>
         <translation type="unfinished">Notadaki Akorlar:</translation>
     </message>
@@ -1863,17 +1868,17 @@
         <translation>Hız:</translation>
     </message>
     <message>
-        <location filename="../source/widgets/playback/playbackwidget.ui" line="103"/>
+        <location filename="../source/widgets/playback/playbackwidget.ui" line="109"/>
         <source>Adjusts the current playback speed.</source>
         <translation>Çalma hızını ayarla.</translation>
     </message>
     <message>
-        <location filename="../source/widgets/playback/playbackwidget.ui" line="175"/>
+        <location filename="../source/widgets/playback/playbackwidget.ui" line="181"/>
         <source>Zoom:</source>
         <translation>Yakınlaştırma:</translation>
     </message>
     <message>
-        <location filename="../source/widgets/playback/playbackwidget.ui" line="220"/>
+        <location filename="../source/widgets/playback/playbackwidget.ui" line="223"/>
         <source>System: 1, Staff: 1, Position: 1, String: 1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1950,1015 +1955,1024 @@
 <context>
     <name>PowerTabEditor</name>
     <message>
-        <location filename="../source/app/clipboard.cpp" line="129"/>
         <source>Cannot paste notes from a different tuning.</source>
-        <translation>Farklı akortlardan notaları yapıştıramazsınız.</translation>
+        <translation type="vanished">Farklı akortlardan notaları yapıştıramazsınız.</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="175"/>
+        <location filename="../source/app/powertabeditor.cpp" line="179"/>
         <source>Toolbox</source>
         <translation>Alet Kutusu</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="248"/>
+        <location filename="../source/app/powertabeditor.cpp" line="252"/>
         <source>Open</source>
         <translation>Aç</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="278"/>
-        <location filename="../source/app/powertabeditor.cpp" line="303"/>
+        <location filename="../source/app/powertabeditor.cpp" line="282"/>
+        <location filename="../source/app/powertabeditor.cpp" line="307"/>
         <source>Error Opening File</source>
         <translation>Dosyayı Açarken Hata</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="279"/>
-        <location filename="../source/app/powertabeditor.cpp" line="400"/>
+        <location filename="../source/app/powertabeditor.cpp" line="283"/>
+        <location filename="../source/app/powertabeditor.cpp" line="405"/>
         <source>Unsupported file type.</source>
         <translation>Desteklenmeyen dosya tipi.</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="304"/>
+        <location filename="../source/app/powertabeditor.cpp" line="308"/>
         <source>Error opening file: %1</source>
         <translation>Dosyayı açarken hata:%1</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="337"/>
+        <location filename="../source/app/powertabeditor.cpp" line="342"/>
         <source>Close Document</source>
         <translation>Belgeyi Kapat</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="338"/>
+        <location filename="../source/app/powertabeditor.cpp" line="343"/>
         <source>The document has been modified.</source>
         <translation>Belge değiştirildi.</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="339"/>
+        <location filename="../source/app/powertabeditor.cpp" line="344"/>
         <source>Do you want to save your changes?</source>
         <translation>Değişiklikleri kaydetmek istiyor musunuz?</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="399"/>
-        <location filename="../source/app/powertabeditor.cpp" line="414"/>
+        <location filename="../source/app/powertabeditor.cpp" line="404"/>
+        <location filename="../source/app/powertabeditor.cpp" line="419"/>
         <source>Error Saving File</source>
         <translation>Dosyayı Kaydederken Hata Oluştu</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="415"/>
+        <location filename="../source/app/powertabeditor.cpp" line="420"/>
         <source>Error saving file: %1</source>
         <translation>Dosya kaydedilirken hata oluştu: %1</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="446"/>
+        <location filename="../source/app/powertabeditor.cpp" line="451"/>
         <source>Save As</source>
         <translation>Farklı Kaydet</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="538"/>
+        <location filename="../source/app/powertabeditor.cpp" line="544"/>
         <source>Cut Notes</source>
         <translation>Notaları Kes</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="554"/>
+        <location filename="../source/app/powertabeditor.cpp" line="560"/>
         <source>The clipboard does not contain any notes.</source>
         <translation>Pano herhangi bir nota içermiyor.</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="559"/>
+        <location filename="../source/app/powertabeditor.cpp" line="565"/>
         <source>Paste Notes</source>
         <translation>Nota Yapıştır</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="604"/>
+        <location filename="../source/app/powertabeditor.cpp" line="618"/>
         <source>Midi Error</source>
         <translation>Midi Hatası</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="626"/>
+        <location filename="../source/app/powertabeditor.cpp" line="640"/>
         <source>Pause</source>
         <translation>Duraklat</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="662"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2303"/>
+        <location filename="../source/app/powertabeditor.cpp" line="676"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2382"/>
         <source>Play</source>
         <translation>Oynat</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="885"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2466"/>
+        <location filename="../source/app/powertabeditor.cpp" line="899"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2545"/>
         <source>Remove Position</source>
         <translation>Pozisyonu Kaldır</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="973"/>
+        <location filename="../source/app/powertabeditor.cpp" line="987"/>
         <source>Edit Chord Text</source>
         <translation>Akor Yazısını Düzenle</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1010"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1024"/>
         <source>Edit Text Item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1058"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1072"/>
         <source>Edit Chord Diagram</source>
         <translation>Akor Diyagramını Düzenle</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1156"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1170"/>
         <source>Edit Note Duration</source>
         <translation>Nota Süresini Düzenle</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1386"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1400"/>
         <source>Cannot add a multi-bar rest to a non-empty measure.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1399"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1413"/>
         <source>Edit Multi-Bar Rest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1476"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1490"/>
         <source>Edit Tempo Marker</source>
         <translation>Tempo İşaretini Düzenle</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1515"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1529"/>
         <source>Edit Alteration of Pace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1562"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1576"/>
         <source>Edit Musical Direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1600"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1614"/>
         <source>Edit Repeat Ending</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1704"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1718"/>
         <source>Edit Volume Swell</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1741"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1755"/>
         <source>Edit Tremolo Bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1841"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1855"/>
         <source>Edit Bend</source>
         <translation>Bükmeyi Düzenle</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1965"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1979"/>
         <source>Edit Player Change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2192"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2264"/>
         <source>Untitled</source>
         <translation>Başlıksız</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2205"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2277"/>
         <source>&amp;New</source>
         <translation>&amp;Yeni</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2210"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2282"/>
         <source>&amp;Open...</source>
         <translation>&amp;Aç...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2215"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2287"/>
         <source>&amp;Close Tab</source>
         <translation>&amp;Sekmeyi Kapa</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2220"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2292"/>
         <source>Save</source>
         <translation>Kaydet</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2226"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2298"/>
         <source>Save As...</source>
         <translation>Farklı Kaydet...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2232"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2304"/>
         <source>Print...</source>
         <translation>Yazdır...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2238"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2310"/>
         <source>Print Preview...</source>
         <translation>Yazdırma Örneği...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2242"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2315"/>
+        <source>Open Backup Folder...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../source/app/powertabeditor.cpp" line="2321"/>
         <source>Bulk Converter...</source>
         <translation>Toplu Çevirici...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2248"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2327"/>
         <source>Customize Shortcuts...</source>
         <translation>Kısayolları Kişiselleştir...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2254"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2333"/>
         <source>&amp;Preferences...</source>
         <translation>&amp;Seçenekler...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2260"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2339"/>
         <source>&amp;Quit</source>
         <translation>&amp;Çıkış</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2265"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2344"/>
         <source>&amp;Undo</source>
         <translation>&amp;Geri Al</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2268"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2347"/>
         <source>&amp;Redo</source>
         <translation>&amp;Tekrarla</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2272"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2351"/>
         <source>Cut</source>
         <translation>Kes</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2276"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2355"/>
         <source>Copy</source>
         <translation>Kopyala</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2281"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2360"/>
         <source>Paste</source>
         <translation>Yapıştır</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2285"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2364"/>
         <source>Polish Score</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2290"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2369"/>
         <source>Polish System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2297"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2376"/>
         <source>File Information...</source>
         <translation>Dosya Bilgisi...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2315"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2394"/>
         <source>Play From Start Of Measure</source>
         <translation>Ölçünün Başından Çal</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2322"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2401"/>
         <source>Stop</source>
         <translation>Dur</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2326"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2405"/>
         <source>Rewind</source>
         <translation>Geriye Sar</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2331"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2410"/>
         <source>Metronome</source>
         <translation>Metronom</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2337"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2416"/>
         <source>Count-In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2345"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2424"/>
         <source>First Section</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2351"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2430"/>
         <source>Next Section</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2357"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2436"/>
         <source>Previous Section</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2363"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2442"/>
         <source>Last Section</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2369"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2448"/>
         <source>Insert Space</source>
         <translation>Boşluk Ekle</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2375"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2454"/>
         <source>Remove Space</source>
         <translation>Boşluğu Kaldır</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2391"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2470"/>
         <source>Move to &amp;Start</source>
         <translation>%Başlangıça Taşı</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2397"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2476"/>
         <source>&amp;Next Position</source>
         <translation>&amp;Sonraki Pozisyon</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2403"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2482"/>
         <source>&amp;Previous Position</source>
         <translation>&amp;Önceki Pozisyon</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2409"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2488"/>
         <source>Next String</source>
         <translation>Sonraki Tel</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2415"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2494"/>
         <source>Previous String</source>
         <translation>Önceki Tel</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2421"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2500"/>
         <source>Move to &amp;End</source>
         <translation>&amp;Sona Taşı</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2427"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2506"/>
         <source>Next Staff</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2433"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2512"/>
         <source>Previous Staff</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2438"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2517"/>
         <source>Next Bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2444"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2523"/>
         <source>Previous Bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2460"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2539"/>
         <source>Remove Selected Item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2471"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2550"/>
         <source>Go To Barline...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2477"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2556"/>
         <source>Go To Rehearsal Sign...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2484"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2563"/>
         <source>Chord Name...</source>
         <translation>Akor İsmi...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2490"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2569"/>
         <source>Text...</source>
         <translation>Yazı...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2498"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2577"/>
         <source>Add Chord Diagram...</source>
         <translation>Akor Diagramı Ekle...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2503"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2582"/>
         <source>Insert System At End</source>
         <translation>Sona Sistem Ekle</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2509"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2588"/>
         <source>Insert System Before</source>
         <translation>Önceye Sistem Ekle</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2516"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2595"/>
         <source>Insert System After</source>
         <translation>Sonraya Sistem Ekle</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2523"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2602"/>
         <source>Remove Current System</source>
         <translation>Şimdiki Sistemi Kaldır</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2531"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2610"/>
         <source>Insert Staff Before</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2537"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2616"/>
         <source>Insert Staff After</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2543"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2622"/>
         <source>Remove Current Staff</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2548"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2627"/>
         <source>Increase</source>
         <translation>Arttır</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2555"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2634"/>
         <source>Decrease</source>
         <translation>Azalt</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2564"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2707"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2643"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2786"/>
         <source>Whole</source>
         <translation>Tam</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2567"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2709"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2646"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2788"/>
         <source>Half</source>
         <translation>Yarım</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2570"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2711"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2649"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2790"/>
         <source>Quarter</source>
         <translation>Çeyrek</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2573"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2713"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2652"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2792"/>
         <source>8th</source>
         <translation>8 lik</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2576"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2715"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2655"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2794"/>
         <source>16th</source>
         <translation>16 lık</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2579"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2717"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2658"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2796"/>
         <source>32nd</source>
         <translation>32 lik</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2583"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2720"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2662"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2799"/>
         <source>64th</source>
         <translation>64 lük</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2588"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2667"/>
         <source>Increase Duration</source>
         <translation>Süreyi Arttır</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2595"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2674"/>
         <source>Decrease Duration</source>
         <translation>Süreyi Azalt</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2602"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2681"/>
         <source>Dotted</source>
         <translation>Noktalı</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2606"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2685"/>
         <source>Double Dotted</source>
         <translation>Çift Noktalı</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2611"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2690"/>
         <source>Add Dot</source>
         <translation>Nokta Ekle</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2615"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2694"/>
         <source>Remove Dot</source>
         <translation>Noktayı Kaldır</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2619"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2698"/>
         <source>Left Hand Fingering...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2628"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2707"/>
         <source>Shift String Up</source>
         <translation>Teli Yukarı Kaydır</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2634"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2713"/>
         <source>Shift String Down</source>
         <translation>Teli Aşşağı Kaydır</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2639"/>
-        <location filename="../source/app/powertabeditor.cpp" line="3933"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2718"/>
+        <location filename="../source/app/powertabeditor.cpp" line="4010"/>
         <source>Tied</source>
         <translation>Bağlı</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2644"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2723"/>
         <source>Muted</source>
         <translation>Susturulmuş</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2647"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2726"/>
         <source>Ghost Note</source>
         <translation>Hayalet Nota</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2651"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2730"/>
         <source>Fermata</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2655"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2734"/>
         <source>Let Ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2659"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2738"/>
         <source>Grace Note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2664"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2743"/>
         <source>Staccato</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2668"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2747"/>
         <source>Accent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2672"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2751"/>
         <source>Heavy Accent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2678"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2757"/>
         <source>8va</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2681"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2760"/>
         <source>15ma</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2684"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2763"/>
         <source>8vb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2687"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2766"/>
         <source>15mb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2691"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2770"/>
         <source>Triplet</source>
         <translation>Üçleme</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2698"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2777"/>
         <source>Irregular Grouping</source>
         <translation>Düzensiz Guruplama</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2724"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2803"/>
         <source>Add Rest</source>
         <translation>Sus Ekle</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2730"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2809"/>
         <source>Multi-Bar Rest...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2738"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2817"/>
         <source>Rehearsal Sign...</source>
         <translation>Prova İşareti...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2745"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2824"/>
         <source>Tempo Marker...</source>
         <translation>Tempo İşareti...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2752"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2831"/>
         <source>Alteration of Pace...</source>
         <translation>Tempo Değişimi...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2758"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2837"/>
         <source>Edit Key Signature...</source>
         <translation>Anahtar İşaretini Düzenle...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2765"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2844"/>
         <source>Edit Time Signature...</source>
         <translation>Zaman İşaretini Düzenle...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2772"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2851"/>
         <source>Insert Standard Barline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2779"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2858"/>
         <source>Barline...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2785"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2864"/>
         <source>Musical Direction...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2793"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2872"/>
         <source>Repeat Ending...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2801"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2880"/>
         <source>Dynamic...</source>
         <translation>Dinamik...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2808"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2811"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2814"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2817"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2820"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2823"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2826"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2829"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2887"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2890"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2893"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2896"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2899"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2902"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2905"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2908"/>
         <source>Dynamics</source>
         <translation>Dinamikler</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2834"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2913"/>
         <source>Volume Swell...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2841"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2920"/>
         <source>Hammer On/Pull Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2849"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2928"/>
         <source>Hammer On From Nowhere</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2854"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2933"/>
         <source>Pull Off To Nowhere</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2858"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2937"/>
         <source>Natural Harmonic</source>
         <translation type="unfinished">Doğal Harmonik</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2863"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2942"/>
         <source>Artificial Harmonic...</source>
         <translation type="unfinished">Yapay Harmonik...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2870"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2949"/>
         <source>Tapped Harmonic...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2879"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2958"/>
         <source>Bend...</source>
         <translation>Bükme...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2886"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2965"/>
         <source>Tremolo Bar...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2892"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2971"/>
         <source>Vibrato</source>
         <translation type="unfinished">Titreştirme</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2897"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2976"/>
         <source>Wide Vibrato</source>
         <translation type="unfinished">Geniş Titreştirme</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2902"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2981"/>
         <source>Palm Mute</source>
         <translation>Avuçla Susturma</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2906"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2985"/>
         <source>Tremolo Picking</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2910"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2989"/>
         <source>Arpeggio Up</source>
         <translation>Yukarı Arpej</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2915"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2994"/>
         <source>Arpeggio Down</source>
         <translation>Aşşağı Arpej</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2920"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2999"/>
         <source>Tap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2924"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3003"/>
         <source>Trill...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2930"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3009"/>
         <source>Pickstroke Up</source>
         <translation>Yukarı Pena Vuruşu</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2935"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3014"/>
         <source>Pickstroke Down</source>
         <translation>Aşşağı Pena Vuruşu</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2941"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3020"/>
         <source>Slide Into From Above</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2946"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3025"/>
         <source>Slide Into From Below</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2951"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3030"/>
         <source>Shift Slide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2955"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3034"/>
         <source>Legato Slide</source>
         <translation type="unfinished">Legato Kaydırma</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2961"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3040"/>
         <source>Slide Out Of Downwards</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2966"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3045"/>
         <source>Slide Out Of Upwards</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2973"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3052"/>
         <source>Add Player</source>
         <translation type="unfinished">Çalıcı Ekle</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2978"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3057"/>
         <source>Add Instrument</source>
         <translation>Enstrüman Ekle</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2982"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3061"/>
         <source>Player Change...</source>
         <translation type="unfinished">Çalıcıyı Değiştir...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2989"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3068"/>
         <source>Tuning Dictionary...</source>
         <translation>Akort Sözlüğü...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2996"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3075"/>
         <source>Edit View Filters...</source>
         <translation>Görsel Filtreleri Düzenle...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3013"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3092"/>
         <source>Next Tab</source>
         <translation>Sonraki Sekme</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3019"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3098"/>
         <source>Previous Tab</source>
         <translation>Önceki Sekme</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3033"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3112"/>
         <source>Zoom In</source>
         <translation>Yakınlaştır</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3038"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3117"/>
         <source>Zoom Out</source>
         <translation>Uzaklaştır</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3044"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3123"/>
         <source>Report Bug...</source>
         <translation>Hata Bildir...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3050"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3129"/>
         <source>Translate This Application...</source>
         <translation>Bu Uygulamayı Tercüme Et...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3056"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3135"/>
         <source>Application Info...</source>
         <translation>Uygulama Bilgisi...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3100"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3179"/>
         <source>Mixer</source>
         <translation>Karıştırıcı</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3125"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3204"/>
         <source>Instruments</source>
         <translation>Enstrümanlar</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3228"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3307"/>
         <source>&amp;File</source>
         <translation>&amp;Dosya</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3239"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3318"/>
         <source>Recent Files</source>
         <translation>Son Dosyalar</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3249"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3329"/>
         <source>&amp;Edit</source>
         <translation>&amp;Düzenle</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3265"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3345"/>
         <source>Play&amp;back</source>
         <translation>Oy&amp;nat</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3274"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3354"/>
         <source>&amp;Position</source>
         <translation>&amp;Pozisyon</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3275"/>
-        <location filename="../source/app/powertabeditor.cpp" line="3311"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3355"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3391"/>
         <source>&amp;Section</source>
         <translation>&amp;Bölüm</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3281"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3361"/>
         <source>&amp;Staff</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3304"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3384"/>
         <source>&amp;Text</source>
         <translation>&amp;Yazı</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3321"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3401"/>
         <source>&amp;Line Spacing</source>
         <translation>&amp;Çizgi Boşluğu</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3326"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3406"/>
         <source>&amp;Notes</source>
         <translation>&amp;Notalar</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3360"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3440"/>
         <source>Octave</source>
         <translation>Oktav</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3370"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3450"/>
         <source>Rests</source>
         <translation>Suslar</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3383"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3463"/>
         <source>&amp;Music Symbols</source>
         <translation>&amp;Müzik Sembolleri</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3397"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3477"/>
         <source>&amp;Tab Symbols</source>
         <translation>&amp;Tab Sembolleri</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3398"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3478"/>
         <source>&amp;Hammer Ons/Pull Offs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3412"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3492"/>
         <source>Slide Into</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3419"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3499"/>
         <source>Slide Out Of</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3439"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3519"/>
         <source>&amp;Player</source>
         <translation type="unfinished">&amp;Çalıcı</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3448"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3528"/>
         <source>&amp;Window</source>
         <translation>&amp;Pencere</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3459"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3539"/>
         <source>&amp;Help</source>
         <translation>&amp;Yardım</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3939"/>
+        <location filename="../source/app/powertabeditor.cpp" line="4016"/>
         <source>Insert Tied Note</source>
         <translation>Bağlı Nota Ekle</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="4034"/>
+        <location filename="../source/app/powertabeditor.cpp" line="4111"/>
         <source>Edit Barline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="4039"/>
+        <location filename="../source/app/powertabeditor.cpp" line="4116"/>
         <source>Insert Barline</source>
         <translation type="unfinished">Ölçü Çizgisi Ekle</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="4045"/>
+        <location filename="../source/app/powertabeditor.cpp" line="4122"/>
         <source>Barline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/build/main.cpp" line="201"/>
+        <location filename="../source/build/main.cpp" line="191"/>
         <source>A guitar tablature editor.</source>
         <translation type="unfinished">Bir gitar tablature düzenleyici.</translation>
     </message>
     <message>
-        <location filename="../source/build/main.cpp" line="207"/>
+        <location filename="../source/build/main.cpp" line="197"/>
         <source>The files to be opened</source>
         <translation>Açılacak dosyalar</translation>
+    </message>
+    <message>
+        <location filename="../source/app/clipboard.cpp" line="130"/>
+        <source>Cannot paste notes from a different number of strings.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2994,9 +3008,13 @@
         <translation>Geniş Titreşim Şiddeti:</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/preferencesdialog.ui" line="86"/>
         <source>Play Notes While Editing</source>
-        <translation>Düzenlerken Notaları Çalmaya Devam Et</translation>
+        <translation type="vanished">Düzenlerken Notaları Çalmaya Devam Et</translation>
+    </message>
+    <message>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="86"/>
+        <source>Play Notes While Editing:</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../source/dialogs/preferencesdialog.ui" line="101"/>
@@ -3012,7 +3030,7 @@
     <message>
         <location filename="../source/dialogs/preferencesdialog.ui" line="122"/>
         <location filename="../source/dialogs/preferencesdialog.ui" line="193"/>
-        <location filename="../source/dialogs/preferencesdialog.ui" line="322"/>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="355"/>
         <source>Preset:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3077,27 +3095,42 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/preferencesdialog.ui" line="297"/>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="296"/>
+        <source>Backup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="304"/>
+        <source>Enable Auto Backup:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="314"/>
+        <source>Backup Interval (seconds):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="330"/>
         <source>Default Instrument</source>
         <translation>Varsayılan Enstüman</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/preferencesdialog.ui" line="312"/>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="345"/>
         <source>Name:</source>
         <translation>İsim:</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/preferencesdialog.ui" line="332"/>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="365"/>
         <source>Tuning:</source>
         <translation>Akort:</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/preferencesdialog.ui" line="339"/>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="372"/>
         <source>Tuning</source>
         <translation>Akort</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/preferencesdialog.cpp" line="146"/>
+        <location filename="../source/dialogs/preferencesdialog.cpp" line="148"/>
         <source>Click to adjust tuning.</source>
         <translation>Akortlamak için tılayın.</translation>
     </message>
@@ -3257,7 +3290,7 @@
         <translation>Pozisyonu Kaldır</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1355"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1369"/>
         <source>Remove Multi-Bar Rest</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3370,67 +3403,67 @@
         <translation type="unfinished">Skor bilgisini düzenlemek için çift tıklayın.</translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="155"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="150"/>
         <source>Double-click to change clef type.</source>
         <translation type="unfinished">Nota anahtarı tipini değiştirmek için çift tıklayın.</translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="197"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="192"/>
         <source>Double-click to edit the number of strings.</source>
         <translation>Tel sayısını düzenlemek için çift tıklayın.</translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="304"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="298"/>
         <source>Double-click to edit rehearsal sign.</source>
         <translation>Prova işaretini düzenlemek için çift tıklayın.</translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="507"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="500"/>
         <source>Double-click to edit repeat endings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="638"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="634"/>
         <source>Double-click to edit tempo marker.</source>
         <translation>Tempo işaretini düzenlemek için çift tıklayın.</translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="745"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="741"/>
         <source>Double-click to edit chord text.</source>
         <translation>Akor yazısını düzenlemek için çift tıklayın.</translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="771"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="767"/>
         <source>Double-click to edit text.</source>
         <translation>Yazıyı değiştirmek için çift tıklayın.</translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="941"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="937"/>
         <source>Double-click to edit the active players.</source>
         <translation>Aktif çalıcıları düzenlemek için çift tıklayın.</translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="1394"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="1389"/>
         <source>Double-click to edit volume swell.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="1414"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="1409"/>
         <source>Double-click to edit tremolo bar.</source>
         <translation>Tremolo kolunu düzenlemek için çift tıklayın.</translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="1589"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="1583"/>
         <source>Double-click to edit dynamic.</source>
         <translation>Dinamiği düzenlemek için çift tıklayın.</translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="1932"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="1926"/>
         <source>Double-click to edit multi-bar rest.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="2185"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="2178"/>
         <source>Double-click to edit bend.</source>
         <translation>Bükmeyi düzenlemek için çift tıklayın.</translation>
     </message>

--- a/translations/powertabeditor_zh_Hans.ts
+++ b/translations/powertabeditor_zh_Hans.ts
@@ -531,12 +531,12 @@
         <translation>...</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/bulkconverterdialog.cpp" line="172"/>
+        <location filename="../source/dialogs/bulkconverterdialog.cpp" line="170"/>
         <source>Convert</source>
         <translation>转换</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/bulkconverterdialog.cpp" line="190"/>
+        <location filename="../source/dialogs/bulkconverterdialog.cpp" line="188"/>
         <source>Directory To Convert</source>
         <translation>待转换目录</translation>
     </message>
@@ -582,7 +582,7 @@
         <translation>图示：</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chorddiagramdialog.cpp" line="48"/>
+        <location filename="../source/dialogs/chorddiagramdialog.cpp" line="47"/>
         <source>Click to edit chord name.</source>
         <translation>点击编辑和弦名称</translation>
     </message>
@@ -610,79 +610,84 @@
         <translation>N.C.</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="95"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="702"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="94"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="694"/>
         <source>C</source>
         <translation>C</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="115"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="722"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="113"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="713"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="135"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="742"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="132"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="732"/>
         <source>E</source>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="155"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="762"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="151"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="751"/>
         <source>F</source>
         <translation>F</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="175"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="782"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="170"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="770"/>
         <source>G</source>
         <translation>G</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="195"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="802"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="189"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="789"/>
         <source>A</source>
         <translation>A</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="215"/>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="822"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="208"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="808"/>
         <source>B</source>
         <translation>B</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="300"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="293"/>
         <source>Brackets</source>
         <translation>括号</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="309"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="302"/>
         <source>Formula:</source>
         <translation>类型：</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="316"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="309"/>
         <source>Additions:</source>
         <translation>附加音：</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="323"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="316"/>
         <source>Extensions:</source>
         <translation>拓展：</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="330"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="323"/>
         <source>Alterations:</source>
         <translation>变和弦：</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="337"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="330"/>
         <source>Bass Note:</source>
         <translation>低音：</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/chordnamedialog.ui" line="911"/>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="892"/>
+        <source>Custom Label</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../source/dialogs/chordnamedialog.ui" line="907"/>
         <source>Chords in Score:</source>
         <translation>乐谱内和弦：</translation>
     </message>
@@ -1806,7 +1811,7 @@
     <message>
         <location filename="../source/widgets/toolbox/notepage.cpp" line="279"/>
         <source>Bend</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">推弦</translation>
     </message>
     <message>
         <location filename="../source/widgets/toolbox/notepage.cpp" line="283"/>
@@ -1847,17 +1852,17 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/widgets/playback/playbackwidget.ui" line="103"/>
+        <location filename="../source/widgets/playback/playbackwidget.ui" line="109"/>
         <source>Adjusts the current playback speed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/widgets/playback/playbackwidget.ui" line="175"/>
+        <location filename="../source/widgets/playback/playbackwidget.ui" line="181"/>
         <source>Zoom:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/widgets/playback/playbackwidget.ui" line="220"/>
+        <location filename="../source/widgets/playback/playbackwidget.ui" line="223"/>
         <source>System: 1, Staff: 1, Position: 1, String: 1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1902,7 +1907,7 @@
     <message>
         <location filename="../source/dialogs/playerchangedialog.cpp" line="41"/>
         <source>Instrument</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">乐器</translation>
     </message>
     <message>
         <location filename="../source/dialogs/playerchangedialog.cpp" line="43"/>
@@ -1934,1014 +1939,1019 @@
 <context>
     <name>PowerTabEditor</name>
     <message>
-        <location filename="../source/app/clipboard.cpp" line="129"/>
-        <source>Cannot paste notes from a different tuning.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../source/app/powertabeditor.cpp" line="175"/>
+        <location filename="../source/app/powertabeditor.cpp" line="179"/>
         <source>Toolbox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="248"/>
+        <location filename="../source/app/powertabeditor.cpp" line="252"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="278"/>
-        <location filename="../source/app/powertabeditor.cpp" line="303"/>
+        <location filename="../source/app/powertabeditor.cpp" line="282"/>
+        <location filename="../source/app/powertabeditor.cpp" line="307"/>
         <source>Error Opening File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="279"/>
-        <location filename="../source/app/powertabeditor.cpp" line="400"/>
+        <location filename="../source/app/powertabeditor.cpp" line="283"/>
+        <location filename="../source/app/powertabeditor.cpp" line="405"/>
         <source>Unsupported file type.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="304"/>
+        <location filename="../source/app/powertabeditor.cpp" line="308"/>
         <source>Error opening file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="337"/>
+        <location filename="../source/app/powertabeditor.cpp" line="342"/>
         <source>Close Document</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="338"/>
+        <location filename="../source/app/powertabeditor.cpp" line="343"/>
         <source>The document has been modified.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="339"/>
+        <location filename="../source/app/powertabeditor.cpp" line="344"/>
         <source>Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="399"/>
-        <location filename="../source/app/powertabeditor.cpp" line="414"/>
+        <location filename="../source/app/powertabeditor.cpp" line="404"/>
+        <location filename="../source/app/powertabeditor.cpp" line="419"/>
         <source>Error Saving File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="415"/>
+        <location filename="../source/app/powertabeditor.cpp" line="420"/>
         <source>Error saving file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="446"/>
+        <location filename="../source/app/powertabeditor.cpp" line="451"/>
         <source>Save As</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="538"/>
+        <location filename="../source/app/powertabeditor.cpp" line="544"/>
         <source>Cut Notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="554"/>
+        <location filename="../source/app/powertabeditor.cpp" line="560"/>
         <source>The clipboard does not contain any notes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="559"/>
+        <location filename="../source/app/powertabeditor.cpp" line="565"/>
         <source>Paste Notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="604"/>
+        <location filename="../source/app/powertabeditor.cpp" line="618"/>
         <source>Midi Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="626"/>
+        <location filename="../source/app/powertabeditor.cpp" line="640"/>
         <source>Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="662"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2303"/>
+        <location filename="../source/app/powertabeditor.cpp" line="676"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2382"/>
         <source>Play</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="885"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2466"/>
+        <location filename="../source/app/powertabeditor.cpp" line="899"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2545"/>
         <source>Remove Position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="973"/>
+        <location filename="../source/app/powertabeditor.cpp" line="987"/>
         <source>Edit Chord Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1010"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1024"/>
         <source>Edit Text Item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1058"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1072"/>
         <source>Edit Chord Diagram</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1156"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1170"/>
         <source>Edit Note Duration</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">编辑音符时值</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1386"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1400"/>
         <source>Cannot add a multi-bar rest to a non-empty measure.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1399"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1413"/>
         <source>Edit Multi-Bar Rest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1476"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1490"/>
         <source>Edit Tempo Marker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1515"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1529"/>
         <source>Edit Alteration of Pace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1562"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1576"/>
         <source>Edit Musical Direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1600"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1614"/>
         <source>Edit Repeat Ending</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1704"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1718"/>
         <source>Edit Volume Swell</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1741"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1755"/>
         <source>Edit Tremolo Bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1841"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1855"/>
         <source>Edit Bend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1965"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1979"/>
         <source>Edit Player Change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2192"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2264"/>
         <source>Untitled</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">未命名</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2205"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2277"/>
         <source>&amp;New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2210"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2282"/>
         <source>&amp;Open...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2215"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2287"/>
         <source>&amp;Close Tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2220"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2292"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2226"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2298"/>
         <source>Save As...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2232"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2304"/>
         <source>Print...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2238"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2310"/>
         <source>Print Preview...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2242"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2315"/>
+        <source>Open Backup Folder...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../source/app/powertabeditor.cpp" line="2321"/>
         <source>Bulk Converter...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2248"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2327"/>
         <source>Customize Shortcuts...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2254"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2333"/>
         <source>&amp;Preferences...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2260"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2339"/>
         <source>&amp;Quit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2265"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2344"/>
         <source>&amp;Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2268"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2347"/>
         <source>&amp;Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2272"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2351"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2276"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2355"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2281"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2360"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2285"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2364"/>
         <source>Polish Score</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2290"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2369"/>
         <source>Polish System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2297"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2376"/>
         <source>File Information...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2315"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2394"/>
         <source>Play From Start Of Measure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2322"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2401"/>
         <source>Stop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2326"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2405"/>
         <source>Rewind</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2331"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2410"/>
         <source>Metronome</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2337"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2416"/>
         <source>Count-In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2345"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2424"/>
         <source>First Section</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2351"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2430"/>
         <source>Next Section</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2357"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2436"/>
         <source>Previous Section</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2363"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2442"/>
         <source>Last Section</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2369"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2448"/>
         <source>Insert Space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2375"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2454"/>
         <source>Remove Space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2391"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2470"/>
         <source>Move to &amp;Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2397"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2476"/>
         <source>&amp;Next Position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2403"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2482"/>
         <source>&amp;Previous Position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2409"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2488"/>
         <source>Next String</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2415"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2494"/>
         <source>Previous String</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2421"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2500"/>
         <source>Move to &amp;End</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2427"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2506"/>
         <source>Next Staff</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2433"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2512"/>
         <source>Previous Staff</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2438"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2517"/>
         <source>Next Bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2444"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2523"/>
         <source>Previous Bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2460"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2539"/>
         <source>Remove Selected Item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2471"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2550"/>
         <source>Go To Barline...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2477"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2556"/>
         <source>Go To Rehearsal Sign...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2484"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2563"/>
         <source>Chord Name...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2490"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2569"/>
         <source>Text...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2498"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2577"/>
         <source>Add Chord Diagram...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2503"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2582"/>
         <source>Insert System At End</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2509"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2588"/>
         <source>Insert System Before</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2516"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2595"/>
         <source>Insert System After</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2523"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2602"/>
         <source>Remove Current System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2531"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2610"/>
         <source>Insert Staff Before</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2537"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2616"/>
         <source>Insert Staff After</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2543"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2622"/>
         <source>Remove Current Staff</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2548"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2627"/>
         <source>Increase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2555"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2634"/>
         <source>Decrease</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2564"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2707"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2643"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2786"/>
         <source>Whole</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2567"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2709"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2646"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2788"/>
         <source>Half</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2570"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2711"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2649"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2790"/>
         <source>Quarter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2573"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2713"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2652"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2792"/>
         <source>8th</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2576"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2715"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2655"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2794"/>
         <source>16th</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2579"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2717"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2658"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2796"/>
         <source>32nd</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2583"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2720"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2662"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2799"/>
         <source>64th</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2588"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2667"/>
         <source>Increase Duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2595"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2674"/>
         <source>Decrease Duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2602"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2681"/>
         <source>Dotted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2606"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2685"/>
         <source>Double Dotted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2611"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2690"/>
         <source>Add Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2615"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2694"/>
         <source>Remove Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2619"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2698"/>
         <source>Left Hand Fingering...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2628"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2707"/>
         <source>Shift String Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2634"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2713"/>
         <source>Shift String Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2639"/>
-        <location filename="../source/app/powertabeditor.cpp" line="3933"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2718"/>
+        <location filename="../source/app/powertabeditor.cpp" line="4010"/>
         <source>Tied</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2644"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2723"/>
         <source>Muted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2647"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2726"/>
         <source>Ghost Note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2651"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2730"/>
         <source>Fermata</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2655"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2734"/>
         <source>Let Ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2659"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2738"/>
         <source>Grace Note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2664"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2743"/>
         <source>Staccato</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2668"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2747"/>
         <source>Accent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2672"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2751"/>
         <source>Heavy Accent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2678"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2757"/>
         <source>8va</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">8va</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2681"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2760"/>
         <source>15ma</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">15ma</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2684"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2763"/>
         <source>8vb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2687"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2766"/>
         <source>15mb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2691"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2770"/>
         <source>Triplet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2698"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2777"/>
         <source>Irregular Grouping</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">连线</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2724"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2803"/>
         <source>Add Rest</source>
         <translation type="unfinished">Add Rest</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2730"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2809"/>
         <source>Multi-Bar Rest...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2738"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2817"/>
         <source>Rehearsal Sign...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2745"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2824"/>
         <source>Tempo Marker...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2752"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2831"/>
         <source>Alteration of Pace...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2758"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2837"/>
         <source>Edit Key Signature...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2765"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2844"/>
         <source>Edit Time Signature...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2772"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2851"/>
         <source>Insert Standard Barline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2779"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2858"/>
         <source>Barline...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2785"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2864"/>
         <source>Musical Direction...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2793"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2872"/>
         <source>Repeat Ending...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2801"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2880"/>
         <source>Dynamic...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2808"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2811"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2814"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2817"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2820"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2823"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2826"/>
-        <location filename="../source/app/powertabeditor.cpp" line="2829"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2887"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2890"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2893"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2896"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2899"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2902"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2905"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2908"/>
         <source>Dynamics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2834"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2913"/>
         <source>Volume Swell...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2841"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2920"/>
         <source>Hammer On/Pull Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2849"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2928"/>
         <source>Hammer On From Nowhere</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2854"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2933"/>
         <source>Pull Off To Nowhere</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2858"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2937"/>
         <source>Natural Harmonic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2863"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2942"/>
         <source>Artificial Harmonic...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2870"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2949"/>
         <source>Tapped Harmonic...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2879"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2958"/>
         <source>Bend...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2886"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2965"/>
         <source>Tremolo Bar...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2892"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2971"/>
         <source>Vibrato</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2897"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2976"/>
         <source>Wide Vibrato</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2902"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2981"/>
         <source>Palm Mute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2906"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2985"/>
         <source>Tremolo Picking</source>
         <translation>拨片颤音（震音）</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2910"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2989"/>
         <source>Arpeggio Up</source>
         <translation>向上琶音</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2915"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2994"/>
         <source>Arpeggio Down</source>
         <translation>向下琶音</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2920"/>
+        <location filename="../source/app/powertabeditor.cpp" line="2999"/>
         <source>Tap</source>
         <translation>点弦</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2924"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3003"/>
         <source>Trill...</source>
         <translation>颤音</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2930"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3009"/>
         <source>Pickstroke Up</source>
         <translation>拨片上拨</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2935"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3014"/>
         <source>Pickstroke Down</source>
         <translation>拨片下拨</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2941"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3020"/>
         <source>Slide Into From Above</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2946"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3025"/>
         <source>Slide Into From Below</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2951"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3030"/>
         <source>Shift Slide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2955"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3034"/>
         <source>Legato Slide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2961"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3040"/>
         <source>Slide Out Of Downwards</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2966"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3045"/>
         <source>Slide Out Of Upwards</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2973"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3052"/>
         <source>Add Player</source>
         <translation>添加演奏者</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2978"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3057"/>
         <source>Add Instrument</source>
         <translation>添加乐器</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2982"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3061"/>
         <source>Player Change...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2989"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3068"/>
         <source>Tuning Dictionary...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="2996"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3075"/>
         <source>Edit View Filters...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3013"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3092"/>
         <source>Next Tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3019"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3098"/>
         <source>Previous Tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3033"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3112"/>
         <source>Zoom In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3038"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3117"/>
         <source>Zoom Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3044"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3123"/>
         <source>Report Bug...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">报告问题...</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3050"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3129"/>
         <source>Translate This Application...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3056"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3135"/>
         <source>Application Info...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3100"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3179"/>
         <source>Mixer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3125"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3204"/>
         <source>Instruments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3228"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3307"/>
         <source>&amp;File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3239"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3318"/>
         <source>Recent Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3249"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3329"/>
         <source>&amp;Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3265"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3345"/>
         <source>Play&amp;back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3274"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3354"/>
         <source>&amp;Position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3275"/>
-        <location filename="../source/app/powertabeditor.cpp" line="3311"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3355"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3391"/>
         <source>&amp;Section</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3281"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3361"/>
         <source>&amp;Staff</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3304"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3384"/>
         <source>&amp;Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3321"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3401"/>
         <source>&amp;Line Spacing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3326"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3406"/>
         <source>&amp;Notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3360"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3440"/>
         <source>Octave</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3370"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3450"/>
         <source>Rests</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">休止符</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3383"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3463"/>
         <source>&amp;Music Symbols</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3397"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3477"/>
         <source>&amp;Tab Symbols</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3398"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3478"/>
         <source>&amp;Hammer Ons/Pull Offs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3412"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3492"/>
         <source>Slide Into</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3419"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3499"/>
         <source>Slide Out Of</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3439"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3519"/>
         <source>&amp;Player</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3448"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3528"/>
         <source>&amp;Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3459"/>
+        <location filename="../source/app/powertabeditor.cpp" line="3539"/>
         <source>&amp;Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="3939"/>
+        <location filename="../source/app/powertabeditor.cpp" line="4016"/>
         <source>Insert Tied Note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="4034"/>
+        <location filename="../source/app/powertabeditor.cpp" line="4111"/>
         <source>Edit Barline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="4039"/>
+        <location filename="../source/app/powertabeditor.cpp" line="4116"/>
         <source>Insert Barline</source>
         <translation type="unfinished">Insert Barline</translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="4045"/>
+        <location filename="../source/app/powertabeditor.cpp" line="4122"/>
         <source>Barline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/build/main.cpp" line="201"/>
+        <location filename="../source/build/main.cpp" line="191"/>
         <source>A guitar tablature editor.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/build/main.cpp" line="207"/>
+        <location filename="../source/build/main.cpp" line="197"/>
         <source>The files to be opened</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../source/app/clipboard.cpp" line="130"/>
+        <source>Cannot paste notes from a different number of strings.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2979,7 +2989,7 @@
     </message>
     <message>
         <location filename="../source/dialogs/preferencesdialog.ui" line="86"/>
-        <source>Play Notes While Editing</source>
+        <source>Play Notes While Editing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2996,7 +3006,7 @@
     <message>
         <location filename="../source/dialogs/preferencesdialog.ui" line="122"/>
         <location filename="../source/dialogs/preferencesdialog.ui" line="193"/>
-        <location filename="../source/dialogs/preferencesdialog.ui" line="322"/>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="355"/>
         <source>Preset:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3023,7 +3033,7 @@
     <message>
         <location filename="../source/dialogs/preferencesdialog.ui" line="219"/>
         <source>General</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">一般</translation>
     </message>
     <message>
         <location filename="../source/dialogs/preferencesdialog.ui" line="225"/>
@@ -3061,29 +3071,44 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/preferencesdialog.ui" line="297"/>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="296"/>
+        <source>Backup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="304"/>
+        <source>Enable Auto Backup:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="314"/>
+        <source>Backup Interval (seconds):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="330"/>
         <source>Default Instrument</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/preferencesdialog.ui" line="312"/>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="345"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">名称：</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/preferencesdialog.ui" line="332"/>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="365"/>
         <source>Tuning:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/dialogs/preferencesdialog.ui" line="339"/>
+        <location filename="../source/dialogs/preferencesdialog.ui" line="372"/>
         <source>Tuning</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">调音</translation>
     </message>
     <message>
-        <location filename="../source/dialogs/preferencesdialog.cpp" line="146"/>
+        <location filename="../source/dialogs/preferencesdialog.cpp" line="148"/>
         <source>Click to adjust tuning.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">点击以调节tune。</translation>
     </message>
 </context>
 <context>
@@ -3182,7 +3207,7 @@
     <message>
         <location filename="../source/actions/removeinstrument.cpp" line="23"/>
         <source>Remove Instrument</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">删除</translation>
     </message>
 </context>
 <context>
@@ -3222,7 +3247,7 @@
     <message>
         <location filename="../source/actions/removeplayer.cpp" line="23"/>
         <source>Remove Player</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">删除演奏者</translation>
     </message>
 </context>
 <context>
@@ -3241,7 +3266,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/app/powertabeditor.cpp" line="1355"/>
+        <location filename="../source/app/powertabeditor.cpp" line="1369"/>
         <source>Remove Multi-Bar Rest</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3354,67 +3379,67 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="155"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="150"/>
         <source>Double-click to change clef type.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="197"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="192"/>
         <source>Double-click to edit the number of strings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="304"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="298"/>
         <source>Double-click to edit rehearsal sign.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="507"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="500"/>
         <source>Double-click to edit repeat endings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="638"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="634"/>
         <source>Double-click to edit tempo marker.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="745"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="741"/>
         <source>Double-click to edit chord text.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="771"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="767"/>
         <source>Double-click to edit text.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="941"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="937"/>
         <source>Double-click to edit the active players.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="1394"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="1389"/>
         <source>Double-click to edit volume swell.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="1414"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="1409"/>
         <source>Double-click to edit tremolo bar.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="1589"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="1583"/>
         <source>Double-click to edit dynamic.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="1932"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="1926"/>
         <source>Double-click to edit multi-bar rest.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../source/painters/systemrenderer.cpp" line="2185"/>
+        <location filename="../source/painters/systemrenderer.cpp" line="2178"/>
         <source>Double-click to edit bend.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3434,7 +3459,7 @@
     <message>
         <location filename="../source/widgets/toolbox/scorepage.cpp" line="32"/>
         <source>Song</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">乐曲</translation>
     </message>
     <message>
         <location filename="../source/widgets/toolbox/scorepage.cpp" line="36"/>
@@ -3558,7 +3583,7 @@
     <message>
         <location filename="../source/dialogs/staffdialog.ui" line="31"/>
         <source>Number of Strings:</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">弦的数量：</translation>
     </message>
     <message>
         <location filename="../source/dialogs/staffdialog.ui" line="41"/>
@@ -3723,7 +3748,7 @@
     <message>
         <location filename="../source/dialogs/tremolobardialog.ui" line="31"/>
         <source>Type:</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">类型：</translation>
     </message>
     <message>
         <location filename="../source/dialogs/tremolobardialog.ui" line="41"/>
@@ -3733,17 +3758,17 @@
     <message>
         <location filename="../source/dialogs/tremolobardialog.ui" line="51"/>
         <source>Bend Duration:</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">推弦时值：</translation>
     </message>
     <message>
         <location filename="../source/dialogs/tremolobardialog.ui" line="63"/>
         <source>Current note duration + next</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">当前+下一音符时值</translation>
     </message>
     <message>
         <location filename="../source/dialogs/tremolobardialog.ui" line="73"/>
         <source>notes</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">音符</translation>
     </message>
     <message>
         <location filename="../source/dialogs/tremolobardialog.cpp" line="32"/>
@@ -3810,12 +3835,12 @@
     <message>
         <location filename="../source/dialogs/tuningdialog.ui" line="17"/>
         <source>Tuning</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">调音</translation>
     </message>
     <message>
         <location filename="../source/dialogs/tuningdialog.ui" line="31"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">名称：</translation>
     </message>
     <message>
         <location filename="../source/dialogs/tuningdialog.ui" line="41"/>
@@ -3830,7 +3855,7 @@
     <message>
         <location filename="../source/dialogs/tuningdialog.ui" line="61"/>
         <source>Number of Strings:</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">弦的数量：</translation>
     </message>
     <message>
         <location filename="../source/dialogs/tuningdialog.ui" line="71"/>
@@ -3858,7 +3883,7 @@
     <message>
         <location filename="../source/dialogs/tuningdictionarydialog.ui" line="25"/>
         <source>Number of Strings:</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">弦的数量：</translation>
     </message>
     <message>
         <location filename="../source/dialogs/tuningdictionarydialog.ui" line="52"/>
@@ -3917,7 +3942,7 @@
     <message>
         <location filename="../source/dialogs/viewfilterdialog.ui" line="139"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">名称：</translation>
     </message>
     <message>
         <location filename="../source/dialogs/viewfilterdialog.ui" line="149"/>
@@ -3951,7 +3976,7 @@
         <location filename="../source/dialogs/volumeswelldialog.ui" line="61"/>
         <location filename="../source/dialogs/volumeswelldialog.ui" line="344"/>
         <source>Off</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">关闭</translation>
     </message>
     <message>
         <location filename="../source/dialogs/volumeswelldialog.ui" line="317"/>


### PR DESCRIPTION
- This should hopefully fix issues with secondary system languages being used unexpectedly when English is the primary system language - if `QTranslator` doesn't find an english translation in the search path, it loads the next available language in the precedence order. Qt itself also provides an `en` translation, so this seems to be the expected pattern

- Also ran the translation update to update the translatable strings for all languages

Fixes: #527