### PR TITLE
Fix #448 and also allow to change a muted note to a real note

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required( VERSION 3.12 )
 
-# Target OS X 10.15 and above. This must be set before the first project() call.
-set( CMAKE_OSX_DEPLOYMENT_TARGET "10.15"
+# Target OS X 14.0 and above. This must be set before the first project() call.
+set( CMAKE_OSX_DEPLOYMENT_TARGET "14.0"
      CACHE STRING "Minimum OS X deployment version"
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,29 +1,24 @@
 cmake_minimum_required( VERSION 3.12 )
 
-
-
-# Target OS X 14.0 and above. This must be set before the first project() call.
-if(APPLE)
+# Target OS X 15.0 and above. This must be set before the first project() call.
+if ( APPLE )
     # Detect macOS version
-    execute_process(
-    COMMAND sw_vers -productVersion
-    OUTPUT_VARIABLE MACOS_VERSION
-    OUTPUT_STRIP_TRAILING_WHITESPACE
+    execute_process (
+        COMMAND sw_vers -productVersion
+        OUTPUT_VARIABLE MACOS_VERSION
+        OUTPUT_STRIP_TRAILING_WHITESPACE
     )
-    string(REGEX MATCH "^[0-9]+" MACOS_MAJOR "${MACOS_VERSION}")
-    message(STATUS "macOS major version: ${MACOS_MAJOR}")
+    string( REGEX MATCH "^[0-9]+" MACOS_MAJOR "${MACOS_VERSION}" )
+    message( STATUS "macOS major version: ${MACOS_MAJOR}" )
 
-    if(MACOS_MAJOR VERSION_LESS 15.0)
-        set(CMAKE_OSX_DEPLOYMENT_TARGET 14.0)
-    else()
-        set(CMAKE_OSX_DEPLOYMENT_TARGET 15.0)
-    endif()
-endif()
+    if ( MACOS_MAJOR VERSION_LESS 15.0 )
+        set( CMAKE_OSX_DEPLOYMENT_TARGET 14.0 )
+    else ()
+        set( CMAKE_OSX_DEPLOYMENT_TARGET 15.0 )
+    endif ()
 
-message(CMAKE_OSX_DEPLOYMENT_TARGET="${CMAKE_OSX_DEPLOYMENT_TARGET}")
-
-
-
+    message( STATUS CMAKE_OSX_DEPLOYMENT_TARGET="${CMAKE_OSX_DEPLOYMENT_TARGET}" )
+endif ()
 
 project( powertabeditor )
 include( CTest )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,29 @@
 cmake_minimum_required( VERSION 3.12 )
 
+
+
 # Target OS X 14.0 and above. This must be set before the first project() call.
-set( CMAKE_OSX_DEPLOYMENT_TARGET "14.0"
-     CACHE STRING "Minimum OS X deployment version"
-)
+if(APPLE)
+    # Detect macOS version
+    execute_process(
+    COMMAND sw_vers -productVersion
+    OUTPUT_VARIABLE MACOS_VERSION
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    string(REGEX MATCH "^[0-9]+" MACOS_MAJOR "${MACOS_VERSION}")
+    message(STATUS "macOS major version: ${MACOS_MAJOR}")
+
+    if(MACOS_MAJOR VERSION_LESS 15.0)
+        set(CMAKE_OSX_DEPLOYMENT_TARGET 14.0)
+    else()
+        set(CMAKE_OSX_DEPLOYMENT_TARGET 15.0)
+    endif()
+endif()
+
+message(CMAKE_OSX_DEPLOYMENT_TARGET="${CMAKE_OSX_DEPLOYMENT_TARGET}")
+
+
+
 
 project( powertabeditor )
 include( CTest )

--- a/source/app/powertabeditor.cpp
+++ b/source/app/powertabeditor.cpp
@@ -2116,19 +2116,11 @@ bool PowerTabEditor::eventFilter(QObject *object, QEvent *event)
                         const Note *note = location.getNote();
                         if (note->hasProperty(Note::Muted))
                         {
-                            // Remove the muted property only from the caret note
-                            // and set the fret number as a single undoable
-                            // action.
-                            ScoreLocation singleNoteLocation(location);
-                            singleNoteLocation.setSelectionStart(
-                                location.getPositionIndex());
-                            singleNoteLocation.setSelectionEnd(
-                                location.getPositionIndex());
-
+                            // Remove the muted property and set the fret number
+                            // as a single undoable action.
                             myUndoManager->beginMacro(tr("Edit Tab Number"));
                             myUndoManager->push(
-                                new RemoveNoteProperty(singleNoteLocation,
-                                                       Note::Muted,
+                                new RemoveNoteProperty(location, Note::Muted,
                                                        tr("Muted")),
                                 location.getSystemIndex());
                             myUndoManager->push(

--- a/source/app/powertabeditor.cpp
+++ b/source/app/powertabeditor.cpp
@@ -2078,7 +2078,7 @@ bool PowerTabEditor::eventFilter(QObject *object, QEvent *event)
         QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
         // x for a muted note
         const bool isMutedKey = (keyEvent->key() == Qt::Key_X);
-        if (keyEvent->key() >= Qt::Key_0 && keyEvent->key() <= Qt::Key_9 ||
+        if ((keyEvent->key() >= Qt::Key_0 && keyEvent->key() <= Qt::Key_9) ||
             isMutedKey)
         {
             const int number = isMutedKey ? 0 : (keyEvent->key() - Qt::Key_0);

--- a/source/app/powertabeditor.cpp
+++ b/source/app/powertabeditor.cpp
@@ -2076,9 +2076,12 @@ bool PowerTabEditor::eventFilter(QObject *object, QEvent *event)
     if (scorearea && event->type() == QEvent::KeyPress)
     {
         QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
-        if (keyEvent->key() >= Qt::Key_0 && keyEvent->key() <= Qt::Key_9)
+        // x for a muted note
+        const bool isMutedKey = (keyEvent->key() == Qt::Key_X);
+        if (keyEvent->key() >= Qt::Key_0 && keyEvent->key() <= Qt::Key_9 ||
+            isMutedKey)
         {
-            const int number = keyEvent->key() - Qt::Key_0;
+            const int number = isMutedKey ? 0 : (keyEvent->key() - Qt::Key_0);
             ScoreLocation &location = getLocation();
 
             // Add a space if the user is attempting to add a note at the end of
@@ -2093,42 +2096,76 @@ bool PowerTabEditor::eventFilter(QObject *object, QEvent *event)
             // unless it's the first position of the system.
             if (!location.getBarline() || location.getPositionIndex() == 0)
             {
-                // Update the existing note if possible.
-                if (location.getNote())
+                if (isMutedKey && !location.getNote())
                 {
-                    myUndoManager->push(new EditTabNumber(location, number),
-                                        location.getSystemIndex());
-                }
-                else
-                {
+                    // Directly insert a new muted note without requiring a
+                    // number to be entered first.
+                    Note mutedNote(location.getString(), 0);
+                    mutedNote.setProperty(Note::Muted);
                     myUndoManager->push(
-                                new AddNote(location,
-                                            Note(location.getString(), number),
-                                            myActiveDurationType),
-                                location.getSystemIndex());
+                        new AddNote(location, mutedNote, myActiveDurationType),
+                        location.getSystemIndex());
+                    return true;
                 }
 
-                if (mySettingsManager->getReadHandle()->get(
-                        Settings::PlayNotesWhileEditing))
+                if (!isMutedKey)
                 {
-                    const ScoreLocation &location = getLocation();
-                    // Generate the midi data and then transfer it to the midi
-                    // thread.
-                    MidiFile midi_data = MidiPlayer::generateSingleNote(
-                        location, *mySettingsManager);
-                    MidiPlaybackSettings initial_settings(100,
-                                                          location.getScore());
+                    // Update the existing note if possible.
+                    if (location.getNote())
+                    {
+                        const Note *note = location.getNote();
+                        if (note->hasProperty(Note::Muted))
+                        {
+                            // Remove the muted property and set the fret number
+                            // as a single undoable action.
+                            myUndoManager->beginMacro(tr("Edit Tab Number"));
+                            myUndoManager->push(
+                                new RemoveNoteProperty(location, Note::Muted,
+                                                       tr("Muted")),
+                                location.getSystemIndex());
+                            myUndoManager->push(
+                                new EditTabNumber(location, number),
+                                location.getSystemIndex());
+                            myUndoManager->endMacro();
+                        }
+                        else
+                        {
+                            myUndoManager->push(
+                                new EditTabNumber(location, number),
+                                location.getSystemIndex());
+                        }
+                    }
+                    else
+                    {
+                        myUndoManager->push(
+                                    new AddNote(location,
+                                                Note(location.getString(), number),
+                                                myActiveDurationType),
+                                    location.getSystemIndex());
+                    }
 
-                    QMetaObject::invokeMethod(
-                        myMidiPlayer,
-                        [=, this, midi_data = std::move(midi_data)]() mutable {
-                            myMidiPlayer->playSingleNote(midi_data, location,
-                                                         initial_settings);
-                        },
-                        Qt::QueuedConnection);
+                    if (mySettingsManager->getReadHandle()->get(
+                            Settings::PlayNotesWhileEditing))
+                    {
+                        const ScoreLocation &location = getLocation();
+                        // Generate the midi data and then transfer it to the midi
+                        // thread.
+                        MidiFile midi_data = MidiPlayer::generateSingleNote(
+                            location, *mySettingsManager);
+                        MidiPlaybackSettings initial_settings(100,
+                                                              location.getScore());
+
+                        QMetaObject::invokeMethod(
+                            myMidiPlayer,
+                            [=, this, midi_data = std::move(midi_data)]() mutable {
+                                myMidiPlayer->playSingleNote(midi_data, location,
+                                                             initial_settings);
+                            },
+                            Qt::QueuedConnection);
+                    }
+
+                    return true;
                 }
-
-                return true;
             }
         }
     }

--- a/source/app/powertabeditor.cpp
+++ b/source/app/powertabeditor.cpp
@@ -2116,11 +2116,19 @@ bool PowerTabEditor::eventFilter(QObject *object, QEvent *event)
                         const Note *note = location.getNote();
                         if (note->hasProperty(Note::Muted))
                         {
-                            // Remove the muted property and set the fret number
-                            // as a single undoable action.
+                            // Remove the muted property only from the caret note
+                            // and set the fret number as a single undoable
+                            // action.
+                            ScoreLocation singleNoteLocation(location);
+                            singleNoteLocation.setSelectionStart(
+                                location.getPositionIndex());
+                            singleNoteLocation.setSelectionEnd(
+                                location.getPositionIndex());
+
                             myUndoManager->beginMacro(tr("Edit Tab Number"));
                             myUndoManager->push(
-                                new RemoveNoteProperty(location, Note::Muted,
+                                new RemoveNoteProperty(singleNoteLocation,
+                                                       Note::Muted,
                                                        tr("Muted")),
                                 location.getSystemIndex());
                             myUndoManager->push(

--- a/source/app/powertabeditor.cpp
+++ b/source/app/powertabeditor.cpp
@@ -2155,7 +2155,6 @@ bool PowerTabEditor::eventFilter(QObject *object, QEvent *event)
                     if (mySettingsManager->getReadHandle()->get(
                             Settings::PlayNotesWhileEditing))
                     {
-                        const ScoreLocation &location = getLocation();
                         // Generate the midi data and then transfer it to the midi
                         // thread.
                         MidiFile midi_data = MidiPlayer::generateSingleNote(


### PR DESCRIPTION
### Description of Change(s)
Add the option to directly insert a new muted note without requiring a number to be entered first.
Add the option to change a muted note to a regular note with some numbers

### Fixes Issue(s)
#448 